### PR TITLE
PoC: Add cleanup fixture

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/sanity/test_cleanup_fixture.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/sanity/test_cleanup_fixture.py
@@ -1,0 +1,18 @@
+import pytest
+
+pytestmark = pytest.mark.suite_my
+
+@pytest.fixture
+def add_cleanup():
+    stack = []
+    def append_to_stack(func, *args, **kwargs):
+        if callable(func):
+            stack.append((func, (*args,), {**kwargs}))
+    yield append_to_stack
+
+    for func, args, kwargs in stack:
+        func(*args, **kwargs)
+
+@pytest.mark.asyncio
+async def test_cleanup_fixture(testbed, add_cleanup):
+    add_cleanup(print, "asd", 123)


### PR DESCRIPTION
The fixture exposes a method that allows to add functions to a stack. After the test run all of the functions from the stack will be called one by one with their respective arguments.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>