### PR TITLE
Update IPv4 tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
@@ -35,7 +35,6 @@ DEFAULT_LOGGER = "DENT"
 # consistent
 
 PYTEST_SUITES = {
-    "suite_functional_bridging": "Functional bridging tests",
     "suite_test": "Test marker",
     "suite_clean_config": "Bringup the switch in clean state",
     "suite_unittest": "Example suite for writing unit testcases which are run during bb",
@@ -69,11 +68,11 @@ PYTEST_SUITES = {
     "suite_acl_performance": "ACL Performance related tests",
     "suite_poe_cli": "POE related tests with the cli tool",
     "suite_cleanup": "Test marker for test cleanup",
-    "suite_functional_ipv4": "IPv4 related tests",
+    "suite_functional_ipv4": "Functional IPv4 tests",
+    "suite_functional_bridging": "Functional bridging tests",
 }
 
 PYTEST_SUITE_GROUPS = {
-    "suite_group_functional": ["suite_functional_bridging"],
     "suite_group_test": ["suite_test", "suite_feature_f1", "suite_feature_f2"],
     "suite_group_clean_config": ["suite_clean_config"],
     "suite_group_l3_tests": ["suite_iproute2", "suite_arp"],
@@ -104,5 +103,8 @@ PYTEST_SUITE_GROUPS = {
     "suite_group_connection": ["suite_connection"],
     "suite_group_platform": ["suite_poe", "suite_onlpdump", "suite_lldp"],
     "suite_group_cleanup": ["suite_cleanup"],
-    "suite_group_functional": ["suite_functional_ipv4"],
+    "suite_group_functional": [
+        "suite_functional_ipv4",
+        "suite_functional_bridging",
+    ],
 }

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/conftest.py
@@ -1,0 +1,37 @@
+import pytest_asyncio
+
+from dent_os_testbed.lib.os.sysctl import Sysctl
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def enable_ipv4_forwarding(testbed):
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        print("The testbed does not have enough dent with tgen connections")
+        return
+    dent = dent_devices[0].host_name
+    ip_forward = "net.ipv4.ip_forward"
+
+    # Get ip_forward to restore it later
+    out = await Sysctl.get(input_data=[{dent: [
+        {"variable": ip_forward, "options": "-n"}
+    ]}])
+    assert out[0][dent]["rc"] == 0
+    default_value = int(out[0][dent]["result"])
+
+    # Enable ipv4 forwarding
+    out = await Sysctl.set(input_data=[{dent: [
+        {"variable": ip_forward, "value": 1}
+    ]}])
+    assert out[0][dent]["rc"] == 0
+
+    yield  # Run the test
+
+    # Restore original value
+    out = await Sysctl.set(input_data=[{dent: [
+        {"variable": ip_forward, "value": default_value}
+    ]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.suite_functional_ipv4
 
 def get_random_ip():
     ip = [random.randint(11, 126), random.randint(1, 254), random.randint(1, 254), random.randint(1, 253)]
-    peer = ip[:-1] + [ip[-1] + 1]
+    peer = ip[:-1] + [ip[-1] ^ 1]
     plen = random.randint(1, 31)
     return ".".join(map(str, ip)), ".".join(map(str, peer)), plen
 

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv4/test_ipv4_routing.py
@@ -1,7 +1,6 @@
 import asyncio
 import pytest
 import random
-import itertools
 
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.lib.ip.ip_route import IpRoute
@@ -87,16 +86,11 @@ async def test_ipv4_random_routing(testbed):
     await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
 
     # 5. Generate traffic and verify reception
-    streams = {
-        f"{tg1} <-> {tg2}": {
-            "type": "ipv4",
-            "ip_source": dev_groups[tg1][0]["name"],
-            "ip_destination": dev_groups[tg2][0]["name"],
-            "protocol": "ip",
-            "rate": "1000",  # pps
-            "bi_directional": True,
-        } for tg1, tg2 in itertools.combinations(tg_ports, 2)
-    }
+    streams = {"ipv4": {
+        "type": "ipv4",
+        "protocol": "ip",
+        "rate": "1000",  # pps
+    }}
 
     try:
         await tgen_utils_setup_streams(tgen_dev, None, streams)


### PR DESCRIPTION
Update pytest suite groups.
Use cleanup fixtures instead of try-catch-finally.
Add a fixture to automatically enable ipv4 forwarding.
Use `*_` syntax for argument unpacking in list comprehensions.
Update random routing test.
Fix route_between_vlan_devs test.
Fix get_random_ip function.

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>