### PR TITLE
Add ACL tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65511
  bgp router-id 20.20.0.3
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg2/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/agg2/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65511
  bgp router-id 20.20.0.4
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dist1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/dist1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65535
  bgp router-id 20.20.0.1
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra1/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra1/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65534
  bgp router-id 20.20.0.101
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra2/QUAGGA_CONFIG
+++ b/DentOS_Framework/DentOsTestbed/configuration/testbed_config/sit/infra2/QUAGGA_CONFIG
@@ -8,6 +8,7 @@ no zebra nexthop kernel enable
 !
 router bgp 65534
  bgp router-id 20.20.0.102
+ no bgp ebgp-requires-policy
  neighbor INFRA peer-group
  neighbor INFRA remote-as 65534
  neighbor INFRA timers 3 10

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
@@ -71,6 +71,7 @@ PYTEST_SUITES = {
     "suite_functional_ipv4": "Functional IPv4 tests",
     "suite_functional_bridging": "Functional bridging tests",
     "suite_functional_vlan": "VLAN functional tests",
+    "suite_functional_acl": "Functional ACL tests",
 }
 
 PYTEST_SUITE_GROUPS = {
@@ -107,5 +108,6 @@ PYTEST_SUITE_GROUPS = {
     "suite_group_functional": [
         "suite_functional_vlan",
         "suite_functional_bridging",
+        "suite_functional_acl",
         "suite_functional_ipv4"]
 }

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl.py
@@ -1,0 +1,362 @@
+import asyncio
+import pytest
+import random
+
+from dent_os_testbed.lib.tc.tc_filter import TcFilter
+from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
+from dent_os_testbed.lib.ip.ip_link import IpLink
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_clear_traffic_stats,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+)
+from dent_os_testbed.utils.test_utils.tc_flower_utils import (
+    tcutil_generate_rule_with_random_selectors,
+    tcutil_tc_rules_to_tgen_streams,
+    tcutil_get_tc_stats_pref_map,
+    tcutil_verify_tgen_stats,
+    tcutil_verify_tc_stats,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_acl,
+    pytest.mark.usefixtures("cleanup_qdiscs", "cleanup_tgen", "cleanup_bridges"),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.parametrize("action", ["pass", "drop", "trap"])
+async def test_acl_skip_sw_hw_selector(testbed, action):
+    """
+    Test Name: test_acl_skip_sw_hw_selector
+    Test Suite: suite_functional_acl
+    Test Overview: Check that skip_hw/skip_sw selectors are working correctly
+    Test Procedure:
+    1. Initiate test params
+    2. Create bridge and enslave ports to it
+    3. Set link up on interfaces
+    4. Create stream matching the rule
+    5. Create ingress qdisc
+    6. Configure the rule with skip_sw selector
+    7. Send traffic matching the rule
+    8. Verify it applies to HW only
+    9. Configure the rule with skip_hw selector
+    10. Send traffic matching the rule
+    11. Verify it applies to SW only
+    12. Configure the rule with no selector at all (default)
+    13. Send traffic matching the rule
+    14. Verify it applies to both SW and HW
+    """
+    # 1. Initiate test params
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip("The testbed does not have enough dent with tgen connections")
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:2]
+    ports = tgen_dev.links_dict[dent][1][:2]
+    port_with_rule = ports[0]
+    tx_port, rx_port = tg_ports
+    tc_stats_update_time = 5
+    traffic_duration = 10
+    rate_pps = 100
+    bridge = "br0"
+    pref = 49000
+
+    # 2. Create bridge and enslave ports to it
+    out = await IpLink.add(input_data=[{dent: [{"name": bridge, "type": "bridge"}]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create bridge"
+
+    # 3. Set link up on interfaces
+    out = await IpLink.set(input_data=[{dent: [
+        {"device": port, "operstate": "up", "master": bridge} for port in ports
+    ] + [
+        {"device": bridge, "operstate": "up"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to set port state UP"
+
+    # 4. Create stream matching the rule
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {"ixp": tx_port, "ip": "1.1.1.1", "gw": "1.1.1.10", "plen": 24},
+        {"ixp": rx_port, "ip": "1.1.1.2", "gw": "1.1.1.10", "plen": 24},
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    streams = {"stream": {
+        "ip_source": dev_groups[tx_port][0]["name"],
+        "ip_destination": dev_groups[rx_port][0]["name"],
+        "rate": rate_pps,  # pps
+        "type": "raw",
+        # make sure that the packets will be trapped to cpu
+        "dstMac": "ff:ff:ff:ff:ff:ff",
+        "srcMac": "02:00:00:00:00:01",
+    }}
+
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 5. Create ingress qdisc
+    out = await TcQdisc.add(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create qdisc"
+
+    # 6. Configure the rule with skip_sw selector
+    tc_rule = tcutil_generate_rule_with_random_selectors(
+        port_with_rule, pref=pref, action=action, skip_sw=True, want_proto=False)
+    out = await TcFilter.add(input_data=[{dent: [tc_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rule"
+
+    # 7. Send traffic matching the rule
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # 8. Verify it applies to HW only
+    await asyncio.sleep(tc_stats_update_time)  # wait for tc stats to update
+    ixia_stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    tc_stats = await tcutil_get_tc_stats_pref_map(dent, port_with_rule)
+    await tcutil_verify_tgen_stats(tgen_dev, ixia_stats.Rows, rule_action=action, actual_pps=rate_pps)
+    tx_packets = int(ixia_stats.Rows["Tx Frames"])
+    await tcutil_verify_tc_stats(dent_dev, tx_packets, tc_stats[pref], stats_type="hw")
+
+    # 9. Configure the rule with skip_hw selector
+    out = await TcFilter.delete(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress", "pref": pref}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to remove tc rule"
+
+    tc_rule = tcutil_generate_rule_with_random_selectors(
+        port_with_rule, pref=pref, action=action, skip_hw=True, want_proto=False)
+
+    out = await TcFilter.add(input_data=[{dent: [tc_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rule"
+
+    # 10. Send traffic matching the rule
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # 11. Verify it applies to SW only
+    await asyncio.sleep(tc_stats_update_time)  # wait for tc stats to update
+    ixia_stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    tc_stats = await tcutil_get_tc_stats_pref_map(dent, port_with_rule)
+    # broadcast traffic with sw rule will pass
+    await tcutil_verify_tgen_stats(tgen_dev, ixia_stats.Rows,
+                                   rule_action="pass", actual_pps=rate_pps)
+    tx_packets = int(ixia_stats.Rows["Tx Frames"])
+    await tcutil_verify_tc_stats(dent_dev, tx_packets, tc_stats[pref], stats_type="sw")
+
+    # 12. Configure the rule with no selector at all (default)
+    out = await TcFilter.delete(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress", "pref": pref}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to remove tc rule"
+
+    tc_rule = tcutil_generate_rule_with_random_selectors(
+        port_with_rule, pref=pref, action=action, want_proto=False)
+
+    out = await TcFilter.add(input_data=[{dent: [tc_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rule"
+
+    # 13. Send traffic matching the rule
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # 14. Verify it applies to both SW and HW
+    await asyncio.sleep(tc_stats_update_time)  # wait for tc stats to update
+    ixia_stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    tc_stats = await tcutil_get_tc_stats_pref_map(dent, port_with_rule)
+    # broadcast traffic with trap hw+sw rule will not be forwarded
+    await tcutil_verify_tgen_stats(tgen_dev, ixia_stats.Rows, actual_pps=rate_pps,
+                                   rule_action="drop" if action == "trap" else action)
+    tx_packets = int(ixia_stats.Rows["Tx Frames"])
+    await tcutil_verify_tc_stats(dent_dev, tx_packets, tc_stats[pref], stats_type=["hw", "sw"])
+
+
+async def test_acl_rule_deletion(testbed):
+    """
+    Test Name: test_acl_rule_deletion
+    Test Suite: suite_functional_acl
+    Test Overview: Check that ACL rules are deleted correctly
+    Test Procedure:
+    1. Initiate test params
+    2. Create an ingress queue on first TGDutLink DUT port
+    3. Overflow qdisc with rules with random selectors
+    4. Delete the last and the first rules within the qdisc
+    5. Verify the entries were deleted
+    """
+    # 1. Initiate test params
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 1)
+    if not tgen_dev or not dent_devices:
+        pytest.skip("The testbed does not have enough dent with tgen connections")
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    port = tgen_dev.links_dict[dent][1][0]
+    pref = 10000
+    rule_count = 1536
+
+    # 2. Create an ingress queue on first TGDutLink DUT port
+    out = await TcQdisc.add(input_data=[{dent: [
+        {"dev": port, "direction": "ingress"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create qdisc"
+
+    # 3. Overflow qdisc with rules with random selectors
+    # Run the command in batches, so it does not exceed bash limit
+    batch_size = 400
+    for idx in range(0, rule_count, batch_size):
+        count = batch_size if idx + batch_size < rule_count else rule_count - idx
+        selector_list = ("want_vlan", "want_ip", "want_tcp", "want_port", "want_icmp")
+        out = await TcFilter.add(input_data=[
+            {dent: (tcutil_generate_rule_with_random_selectors(
+                        port, pref=x, want_mac=True,
+                        **{sel: random.randint(0, 1) for sel in selector_list})
+                    for x in range(pref + idx, pref + idx + count))}
+        ])
+        assert out[0][dent]["rc"] == 0, "Failed to add tc rules"
+
+    rc, out = await dent_dev.run_cmd(f"tc filter show dev {port} ingress | grep action | wc -l")
+    assert rc == 0, "Failed to get tc rule count"
+    total_rules = int(out)
+    rc, out = await dent_dev.run_cmd(f"tc filter show dev {port} ingress | grep in_hw | wc -l")
+    assert rc == 0, "Failed to get tc rule count"
+    offloaded_rules = int(out)
+    dent_dev.applog.info(f"Total number of rules: {total_rules}, offloaded: {offloaded_rules}")
+    assert offloaded_rules == rule_count, "Some tc rules were not offloaded"
+
+    # 4. Delete the last and the first rules within the qdisc
+    out = await TcFilter.delete(input_data=[{dent: [
+        {"dev": port, "direction": "ingress", "pref": pref},
+        {"dev": port, "direction": "ingress", "pref": pref + rule_count - 1},
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to remove tc rules"
+
+    # 5. Verify the entries were deleted
+    out = await TcFilter.show(input_data=[{dent: [
+        {"dev": port, "direction": "ingress", "pref": pref},
+        {"dev": port, "direction": "ingress", "pref": pref + rule_count - 1},
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to get tc rules"
+    assert not out[0][dent]["result"].strip(), f"Some of the rules were not deleted\n{out}"
+
+
+async def test_acl_addition_deletion_under_traffic(testbed):
+    """
+    Test Name: test_acl_addition_deletion_under_traffic
+    Test Suite: suite_functional_acl
+    Test Overview: Test ACL rule addition and deletion under traffic
+    Test Procedure:
+    1. Initiate test params
+    2. Create bridge and enslave ports to it
+    3. Set link up on interfaces
+    4. Set up host on TG ports
+    5. Create an ingress qdisc
+    6. Configure the following rules
+       - action drop
+       - rule with randomly generated selectors, action pass
+    7. Set up stream matching the selectors
+    8. Send continuous traffic from first TG port; verify it is forwarded
+    9. Delete the pass rule; verify traffic is not forwarded
+    10. Configure again the deleted rule; verify traffic is forwarded again
+    """
+    # 1. Initiate test params
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip("The testbed does not have enough dent with tgen connections")
+    dent = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:2]
+    ports = tgen_dev.links_dict[dent][1][:2]
+    port_with_rule = ports[0]
+    traffic_duration = 10
+    rate_pps = 10_000
+    bridge = "br0"
+    pref = 49000
+
+    # 2. Create bridge and enslave ports to it
+    out = await IpLink.add(input_data=[{dent: [{"name": bridge, "type": "bridge"}]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create bridge"
+
+    # 3. Set link up on interfaces
+    out = await IpLink.set(input_data=[{dent: [
+        {"device": port, "operstate": "up", "master": bridge} for port in ports
+    ] + [
+        {"device": bridge, "operstate": "up"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to set port state UP"
+
+    # 4. Set up host on TG ports
+    dev_groups = tgen_utils_dev_groups_from_config((
+        {"ixp": tg_ports[0], "ip": "1.1.1.1", "gw": "1.1.1.10", "plen": 24},
+        {"ixp": tg_ports[1], "ip": "1.1.1.2", "gw": "1.1.1.10", "plen": 24},
+    ))
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    # 5. Create an ingress qdisc
+    out = await TcQdisc.add(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create qdisc"
+
+    # 6. Configure rule with randomly generated selectors, action pass
+    pass_rule = tcutil_generate_rule_with_random_selectors(
+        port_with_rule, pref=pref, action="pass", want_ip=True, want_port=True, skip_sw=True)
+    # Configure action drop (higher pref = lower priority)
+    drop_rule = tcutil_generate_rule_with_random_selectors(
+        port_with_rule, pref=pref + 1, action="drop", skip_sw=True, want_proto=False)
+
+    out = await TcFilter.add(input_data=[{dent: [pass_rule, drop_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rules"
+
+    # 7. Set up stream matching the selectors
+    out = await TcFilter.show(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress", "pref": pref, "options": "-j"}
+    ]}], parse_output=True)
+    assert out[0][dent]["rc"] == 0, "Failed to get tc rule"
+
+    streams = tcutil_tc_rules_to_tgen_streams({port_with_rule: out[0][dent]["parsed_output"]},
+                                              frame_rate_pps=rate_pps)
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 8. Send continuous traffic from first TG port
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    # Do not stop traffic
+
+    # Verify it is forwarded
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    # we should only have 1 traffic item and 1 row
+    await tcutil_verify_tgen_stats(tgen_dev, stats.Rows, "pass")
+
+    # 9. Delete the pass rule
+    out = await TcFilter.delete(input_data=[{dent: [
+        {"dev": port_with_rule, "direction": "ingress", "pref": pref}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to delete tc rule"
+
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+
+    # Verify traffic is not forwarded
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    await tcutil_verify_tgen_stats(tgen_dev, stats.Rows, "drop")
+
+    # 10. Configure again the deleted rule
+    out = await TcFilter.add(input_data=[{dent: [pass_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rule"
+
+    await tgen_utils_clear_traffic_stats(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+
+    # Verify traffic is forwarded again
+    stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+    await tcutil_verify_tgen_stats(tgen_dev, stats.Rows, "pass")

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_all_selectors.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_all_selectors.py
@@ -1,0 +1,222 @@
+import asyncio
+import pytest
+import random
+import copy
+
+from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
+from dent_os_testbed.lib.tc.tc_filter import TcFilter
+from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
+from dent_os_testbed.lib.ip.ip_link import IpLink
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_get_traffic_stats,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_stop_traffic,
+)
+from dent_os_testbed.utils.test_utils.tc_flower_utils import (
+    tcutil_generate_rule_with_random_selectors,
+    tcutil_tc_rules_to_tgen_streams,
+    tcutil_get_tc_stats_pref_map,
+    tcutil_verify_tgen_stats,
+    tcutil_verify_tc_stats,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_acl,
+    pytest.mark.usefixtures("cleanup_qdiscs", "cleanup_tgen", "cleanup_bridges"),
+    pytest.mark.asyncio,
+]
+
+
+def get_rule_with_all_selectors(port, pref, action, vlan, is_block):
+    rule = tcutil_generate_rule_with_random_selectors(
+        port=port, pref=pref, want_mac=True, want_vlan=vlan != 0,
+        want_ip=True, want_port=True, action=action, skip_sw=True,
+    )
+    if is_block:
+        rule["block"] = rule.pop("dev")
+    if vlan:
+        rule["protocol"] = "802.1q"
+        rule["filtertype"]["vlan_ethtype"] = "ip"
+        rule["filtertype"]["vlan_id"] = vlan
+    else:
+        rule["protocol"] = "ip"
+    return rule
+
+
+def get_streams_that_do_not_match_rule(rule_matched_stream, list_of_selectors):
+    def update_mac(mac):
+        mac_list = mac.split(":")
+        part = int(mac_list[-1], base=16)
+        part += 1 if part < 250 else -1
+        mac_list[-1] = f"{part:02x}"
+        return ":".join(mac_list)
+
+    def update_ip(ip):
+        ip_list = ip.split(".")
+        part = int(ip_list[-1])
+        part += 1 if part < 250 else -1
+        ip_list[-1] = str(part)
+        return ".".join(ip_list)
+
+    def update_int(number):
+        n = int(number)
+        return str(n + 1 if n < 4000 else n - 1)
+
+    selector_map = {
+        "src_mac":  ("srcMac",   update_mac),
+        "dst_mac":  ("dstMac",   update_mac),
+        "src_ip":   ("srcIp",    update_ip),
+        "dst_ip":   ("dstIp",    update_ip),
+        "src_port": ("srcPort",  update_int),
+        "dst_port": ("dstPort",  update_int),
+        "vlan_id":  ("vlanID",   update_int),
+    }
+    stream_name = next(iter(rule_matched_stream.keys()))
+    unmatched_streams = {}
+
+    for sel in list_of_selectors:
+        if sel not in selector_map:
+            continue
+        field_name, update_func = selector_map[sel]
+        stream = copy.copy(rule_matched_stream[stream_name])
+        if field_name not in stream:
+            continue
+        stream[field_name] = update_func(stream[field_name])
+        unmatched_streams[stream_name + f"_unmatch_{field_name}"] = stream
+
+    return unmatched_streams
+
+
+@pytest.mark.parametrize("action", ["pass", "drop", "trap"])
+@pytest.mark.parametrize("use_tagged_traffic", ["tagged", "untagged"])
+@pytest.mark.parametrize("qdisc_type", ["shared_block", "port"])
+async def test_acl_all_selectors(testbed, action, use_tagged_traffic, qdisc_type):
+    """
+    Test Name: test_acl_all_selectors
+    Test Suite: suite_functional_acl
+    Test Overview: Check that all TC selectors are working correctly
+    Test Procedure:
+    1. Initiate test params
+    2. Create bridge and set link up on it (vlan aware or vlan unaware)
+    3. Enslave interfaces and set link up
+    4. Add vlans to DUT ports
+    5. Create ingress qdisc (port or shared block)
+    6. Create rule-matched traffic
+    7. Prepare streams that do not match the rule (one unmatched stream for each selector)
+    9. Send Traffic from the first TG port
+    10. Verify "pass" and "trap" traffic was forwarded, "drop" was dropped
+    """
+    # 1. Initiate test params
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip("The testbed does not have enough dent with tgen connections")
+    dent_dev = dent_devices[0]
+    dent = dent_dev.host_name
+    tg_ports = tgen_dev.links_dict[dent][0][:2]
+    ports = tgen_dev.links_dict[dent][1][:2]
+    port_with_rule = ports[0]
+
+    use_shared_block = qdisc_type == "shared_block"
+    is_vlan_aware = use_tagged_traffic == "tagged"
+
+    vlan = random.randint(1, 4095) if is_vlan_aware else 0
+    tc_stats_update_time = 5
+    traffic_duration = 10
+    rate_pps = 10_000
+    pref = 49000
+    block = 1
+    bridge = "br0"
+    list_of_selectors = ("src_mac", "dst_mac", "vlan_id",
+                         "src_ip", "dst_ip", "src_port", "dst_port")
+    name = port_with_rule if not use_shared_block else block
+
+    # 2. Create bridge and set link up on it (vlan aware or vlan unaware)
+    config = {"name": bridge, "type": "bridge"}
+    if is_vlan_aware:
+        config["vlan_filtering"] = 1
+        config["vlan_default_pvid"] = 0
+    out = await IpLink.add(input_data=[{dent: [config]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create bridge"
+
+    # 3. Enslave interfaces and set link up
+    out = await IpLink.set(input_data=[{dent: [
+        {"device": port, "operstate": "up", "master": bridge} for port in ports
+    ] + [
+        {"device": bridge, "operstate": "up"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to set port state UP"
+
+    # 4. Add vlans to DUT ports
+    if is_vlan_aware:
+        out = await BridgeVlan.add(input_data=[{dent: [
+            {"device": port, "vid": vlan, "untagged": False} for port in ports
+        ]}])
+        assert out[0][dent]["rc"] == 0, "Failed to set port state UP"
+
+    # 5. Create ingress qdisc (port or shared block)
+    config = {"dev": port_with_rule, "ingress_block": block, "direction": "ingress"}
+    if use_shared_block:
+        tc_target = "block"
+    else:
+        del config["ingress_block"]
+        tc_target = "dev"
+
+    out = await TcQdisc.add(input_data=[{dent: [config]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create qdisc"
+
+    # 6. Create rule-matched traffic
+    tc_rule = get_rule_with_all_selectors(name, pref, action, vlan, use_shared_block)
+    out = await TcFilter.add(input_data=[{dent: [tc_rule]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rules"
+
+    out = await TcFilter.show(input_data=[{dent: [
+        {tc_target: name, "direction": "ingress", "pref": pref, "options": "-j"}
+    ]}], parse_output=True)
+    assert out[0][dent]["rc"] == 0, "Failed to get tc rule"
+
+    streams = tcutil_tc_rules_to_tgen_streams(
+        {port_with_rule: out[0][dent]["parsed_output"]},
+        frame_rate_pps=rate_pps)
+
+    # 7. Prepare streams that do not match the rule (one unmatched stream for each selector)
+    rule_unmatched_streams = get_streams_that_do_not_match_rule(streams, list_of_selectors)
+    streams.update(rule_unmatched_streams)
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        {"ixp": port, "ip": f"1.1.1.{idx}", "gw": "1.1.1.10",
+         "plen": 24, "vlan": vlan if is_vlan_aware else None}
+        for idx, port in enumerate(tg_ports, start=1)
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)
+
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    # 9. Send Traffic from the first TG port
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(traffic_duration)
+    await tgen_utils_stop_traffic(tgen_dev)
+
+    # 10. Verify "pass" and "trap" traffic was forwarded, "drop" was dropped
+    ixia_stats = await tgen_utils_get_traffic_stats(tgen_dev, "Flow Statistics")
+
+    for row in ixia_stats.Rows:
+        act = action
+        if "unmatch" not in row["Traffic Item"]:  # there should be exactly 1 such traffic item
+            tx_frames = int(row["Tx Frames"])
+        else:  # traffic items that should not be matched by any tc rule
+            act = "pass"
+        # traffic item with a different vlan id should have 100% loss
+        if is_vlan_aware and "unmatch_vlanID" in row["Traffic Item"]:
+            act = "drop"
+        await tcutil_verify_tgen_stats(tgen_dev, row, act, rate_pps)
+
+    await asyncio.sleep(tc_stats_update_time)  # wait for tc stats to update
+    tc_stats = await tcutil_get_tc_stats_pref_map(dent, name, use_shared_block)
+    await tcutil_verify_tc_stats(dent_dev, tx_frames, tc_stats[pref])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_negative.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_negative.py
@@ -1,0 +1,66 @@
+import pytest
+
+from dent_os_testbed.lib.tc.tc_filter import TcFilter
+from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
+
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_acl,
+    pytest.mark.usefixtures("cleanup_qdiscs"),
+    pytest.mark.asyncio,
+]
+
+
+async def test_acl_rule_without_qdisc(testbed):
+    """
+    Test Name: test_acl_rule_without_qdisc
+    Test Suite: suite_functional_acl
+    Test Overview: Check that creating a rule without a qdisc will fail
+    Test Procedure:
+    1. Initiate test params
+    2. Define a qsidc
+    3. Try adding rules to a port - make sure does not fail
+    4. Delete the qdisc
+    5. Try adding rules to a port - make sure it fails
+    """
+    # 1. Initiate test params
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 1)
+    if not tgen_dev or not dent_devices:
+        pytest.skip("The testbed does not have enough dent with tgen connections")
+    dent = dent_devices[0].host_name
+    port = tgen_dev.links_dict[dent][1][0]
+    handle = 10
+
+    # 2. Define a qsidc
+    out = await TcQdisc.add(input_data=[{dent: [
+        {"dev": port, "direction": "clsact", "handle": handle}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create qdisc"
+
+    # 3. Try adding rules to a port - make sure does not fail
+    out = await TcFilter.add(input_data=[{dent: [
+        {"dev": port,
+         "direction": "ingress",
+         "filtertype": {"skip_sw": ""},
+         "action": "drop"}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to create tc rules"
+
+    # 4. Delete the qdisc
+    out = await TcQdisc.delete(input_data=[{dent: [
+        {"dev": port, "direction": "clsact", "handle": handle}
+    ]}])
+    assert out[0][dent]["rc"] == 0, "Failed to delete qdisc"
+
+    # 5. Try adding rules to a port - make sure it fails
+    out = await TcFilter.add(input_data=[{dent: [
+        {"dev": port,
+         "direction": "ingress",
+         "filtertype": {"skip_sw": ""},
+         "action": "drop"}
+    ]}])
+    assert out[0][dent]["rc"] != 0, "Adding rules without qdisc should fail"

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tc_flower_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tc_flower_utils.py
@@ -127,6 +127,27 @@ async def tcutil_cleanup_tc_rules(dent_dev, swp_tgen_ports, swp_tc_rules):
 
 def tcutil_tc_rules_to_tgen_streams(swp_tc_rules, streams=None, start=0, cnt=None,
                                     frame_rate_pps=10, frame_size=256):
+    """
+    - swp_tc_rules:   dict
+    - streams:        streams dict that will be modified
+    - start:          used to specify the first rule index, from which the streams will be created
+    - cnt:            used to specify the number of streams to be created
+    - frame_rate_pps: frame rate for each stream
+    - frame_size:     packet size for each stream
+
+    Expects swp_tc_rules to be a dict:
+    {
+        swp_port: { *output from TcFilter.show()* },
+        ...
+    }
+
+    Returns a dict with streams that match the TC rules:
+    {
+        stream_1: { *stream that matches rule #1* },
+        stream_2: { *stream that matches rule #2* },
+        ...
+    }
+    """
     if streams is None:
         streams = {}
     for swp, rules in swp_tc_rules.items():
@@ -399,7 +420,7 @@ async def tcutil_verify_tc_stats(dev, tx_packets, tc_stats, rule_action=None,
             f"Expected {field} to be {expected}, but got {tc_stats[field]} (max {tolerance = })"
 
 
-async def tcutil_verify_ixia_stats(dev, row, rule_action="pass",
+async def tcutil_verify_tgen_stats(dev, row, rule_action="pass",
                                    actual_pps=10_000, tolerance=0.05):
     """
     Checks that Ixia stats for a specific traffic item is correct based on

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/tc/linux/linux_tc_filter_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/tc/linux/linux_tc_filter_impl.py
@@ -1,3 +1,4 @@
+import json
 from dent_os_testbed.lib.tc.linux.linux_tc_filter import LinuxTcFilter
 
 
@@ -58,4 +59,9 @@ class LinuxTcFilterImpl(LinuxTcFilter):
             cmd += "block {} ".format(params.get("block"))
         if "direction" in params:
             cmd += "{} ".format(params.get("direction"))
+        if "pref" in params:
+            cmd += "pref {} ".format(params["pref"])
         return cmd
+
+    def parse_show(self, command, output, *argv, **kwarg):
+        return json.loads(output)


### PR DESCRIPTION
Update suite groups.
Update tcutil_tc_rules_to_tgen_streams function.
Update LinuxTcFilterImpl class.
Add helper functions.

Tests:
- test_acl_all_selectors
- test_acl_addition_deletion_under_traffic
- test_acl_rule_deletion
- test_acl_rule_without_qdisk
- test_acl_skip_sw_hw_selector

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>