### PR TITLE
Update bridge_link_impl, bridge_mdb_impl, ip_link_impl

### DIFF
--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/bridge/linux/linux_bridge_link_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/bridge/linux/linux_bridge_link_impl.py
@@ -33,6 +33,8 @@ class LinuxBridgeLinkImpl(LinuxBridgeLink):
             cmd += "learning {} ".format("on" if params["learning"] else "off")
         if "flood" in params:
             cmd += "flood {} ".format("on" if params["flood"] else "off")
+        if "fastleave" in params:
+          cmd += "fastleave {} ".format("on" if params["fastleave"] else "off")
 
         return cmd
 

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/bridge/linux/linux_bridge_mdb_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/bridge/linux/linux_bridge_mdb_impl.py
@@ -1,3 +1,5 @@
+import json
+
 from dent_os_testbed.lib.bridge.linux.linux_bridge_mdb import LinuxBridgeMdb
 
 
@@ -15,6 +17,15 @@ class LinuxBridgeMdbImpl(LinuxBridgeMdb):
         params = kwarg["params"]
         cmd = "bridge mdb {} ".format(command)
         ############# Implement me ################
+        mdb_entry_type = params.get("permanent", "temp")
+        if "dev" in params:
+            cmd += "dev {} ".format(params["dev"])
+        if "port" in params:
+            cmd += "port {} ".format(params["port"])
+        if "group" in params:
+            cmd += "grp {} {} ".format(params["group"], mdb_entry_type)
+        if "vid" in params:
+            cmd += "vid {} ".format(params["vid"])
 
         return cmd
 
@@ -24,7 +35,10 @@ class LinuxBridgeMdbImpl(LinuxBridgeMdb):
 
         """
         params = kwarg["params"]
-        cmd = "bridge mdb {} ".format(command)
+        cmd = "bridge {} mdb {} ".format(params.get("options", ""), command)
         ############# Implement me ################
 
         return cmd
+
+    def parse_show(self, command, output, *argv, **kwarg):
+        return json.loads(output)

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/ip/linux/linux_ip_link_impl.py
@@ -135,6 +135,14 @@ class LinuxIpLinkImpl(LinuxIpLink):
             cmd += "master {} ".format((params["master"]))
         if "nomaster" in params:
             cmd += "nomaster"
+        if "mcast_snooping" in params:
+            cmd += "mcast_snooping {} ".format((params["mcast_snooping"]))
+        if "mcast_igmp_version" in params:
+            cmd += "mcast_igmp_version {} ".format((params["mcast_igmp_version"]))
+        if "mcast_querier" in params:
+            cmd += "mcast_querier {} ".format((params["mcast_querier"]))
+        if "mcast_querier_interval" in params:
+            cmd += "mcast_querier_interval {} ".format((params["mcast_querier_interval"]))
         return cmd
 
     def format_show(self, command, *argv, **kwarg):


### PR DESCRIPTION
Updated linux_bridge_link_impl.py, added missing parameter: `fastleave`.
Updated linux_bridge_mdb_impl.py, added missing parametrs: `device, port, group, vid` and funtion to `parse_output`. 
Updated linux_ip_link_impl.py, added missing parametrs: `type, mcast_snooping, mcast_igmp_version, mcast_querier, mcast_querier_interval`. 


