### PR TITLE
Add options to test traffic with smaller frame sizes

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -795,3 +795,16 @@ async def tgen_utils_update_l1_config(device, tgen_ports, speed=None, autoneg=Tr
          "duplex": duplex}]}])
     device.applog.info(out)
     assert out[0][device.host_name]["rc"] == 0, f'Failed updating L1 config: {out[0][device.host_name]["result"]}'
+
+
+async def tgen_utils_switch_min_frame_size(device, enable=False):
+    """
+    Enable/disable smaller frame size (4 Byte Signature)
+    Args:
+        device (DeviceType): Ixia device
+        enable (bool): Enable/disable smaller frame size
+    """
+    device.applog.info(f"{'En' if enable else 'Dis'}abling smaller frame size (4 Byte Signature)")
+    out = await TrafficGen.switch_min_frame_size(input_data=[{device.host_name: [{"enable_min_size": enable}]}])
+    device.applog.info(out)
+    assert out[0][device.host_name]["rc"] == 0, 'Failed to enable/disable min frame sizes'

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
@@ -36,10 +36,11 @@
           send_arp - [port, src_ip]
           clear_traffic - [traffic_names]
           update_l1_config - ['speed', 'autoneg', 'ixia_ports']
+          switch_min_frame_size - [enable_min_size]
     apis: ['connect', 'disconnect', 'load_config', 'save_config', 'set_traffic', 'start_traffic', 'stop_traffic',
            'get_stats', 'clear_stats', 'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats',
            'clear_protocol_stats', 'send_arp', 'send_ns', 'send_ping', 'clear_traffic',
-           'get_drilldown_stats', 'update_l1_config']
+           'get_drilldown_stats', 'update_l1_config', 'switch_min_frame_size']
     members:
     - name: client_addr
       type: ip_addr_t
@@ -85,3 +86,7 @@
       type: string
       desc: |
         Duplex on port
+    - name: enable_min_size
+      type: bool
+      desc: |
+        Traffic Generator smaller frame sizes option

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
@@ -24,6 +24,7 @@
           send_ns - [port, src_ip]
           update_l1_config - ['speed', 'autoneg', 'tgen_ports', 'duplex']
           clear_traffic - [traffic_names]
+          switch_min_frame_size - [enable_min_size]
      implements: "dent:traffic:traffic_gen"
      platforms: ['ixnetwork']
      commands:
@@ -84,3 +85,9 @@
         desc: |
          - IxiaClient
            update_l1_config - ['speed', 'autoneg', 'tgen_ports', 'duplex']
+      - name: switch_min_frame_size
+        apis: ['switch_min_frame_size']
+        params: ['enable_min_size']
+        desc: |
+         - IxiaClient
+           switch_min_frame_size - ['enable_min_size']

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
@@ -27,6 +27,7 @@ class IxnetworkIxiaClient(TestLibObject):
             send_ns - [port, src_ip]
             update_l1_config - ['speed', 'autoneg', 'tgen_ports', 'duplex']
             clear_traffic - [traffic_names]
+            switch_min_frame_size - [enable_min_size]
         
     """
     def format_connect(self, command, *argv, **kwarg):
@@ -92,6 +93,15 @@ class IxnetworkIxiaClient(TestLibObject):
     def parse_update_l1_config(self, command, output, *argv, **kwarg):
         raise NotImplementedError
         
+    def format_switch_min_frame_size(self, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def run_switch_min_frame_size(self, device, command, *argv, **kwarg):
+        raise NotImplementedError
+        
+    def parse_switch_min_frame_size(self, command, output, *argv, **kwarg):
+        raise NotImplementedError
+        
     def format_command(self, command, *argv, **kwarg):
         if command in ['connect', 'disconnect']:
             return self.format_connect(command, *argv, **kwarg)
@@ -113,6 +123,10 @@ class IxnetworkIxiaClient(TestLibObject):
         
         if command in ['update_l1_config']:
             return self.format_update_l1_config(command, *argv, **kwarg)
+        
+        if command in ['switch_min_frame_size']:
+            return self.format_switch_min_frame_size(command, *argv, **kwarg)
+        
         
         raise NameError("Cannot find command "+command)
         
@@ -138,6 +152,10 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['update_l1_config']:
             return self.run_update_l1_config(device_obj, command, *argv, **kwarg)
         
+        if command in ['switch_min_frame_size']:
+            return self.run_switch_min_frame_size(device_obj, command, *argv, **kwarg)
+        
+        
         print (len(command))
         raise NameError("Cannot find command "+command)
         
@@ -162,6 +180,10 @@ class IxnetworkIxiaClient(TestLibObject):
         
         if command in ['update_l1_config']:
             return self.parse_update_l1_config(command, output, *argv, **kwarg)
+        
+        if command in ['switch_min_frame_size']:
+            return self.parse_switch_min_frame_size(command, output, *argv, **kwarg)
+        
         
         raise NameError("Cannot find command "+command)
         

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -100,7 +100,6 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                                    "igmpv2", "igmpv3MembershipQuery", "igmpv3MembershipReport")
             }
 
-            IxnetworkIxiaClientImpl.ixnet.Traffic.EnableMinFrameSize = True
             device.applog.info("Connection to Ixia REST API Server Established")
             ixia_ports = param["tgen_ports"]
             swp_ports = param["swp_ports"]
@@ -735,6 +734,19 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                 device.applog.info(f"Changing autoneg to {autoneg} on tgen_port {required_ixia_port.Name}")
                 card.update(AutoNegotiate=autoneg, Speed=ixia_speed)
             return 0, ""
+    
+    def run_switch_min_frame_size(self, device, command, *argv, **kwarg):
+        if not IxnetworkIxiaClientImpl.ixnet:
+            return 1, "Ixia not connected"
+        if command == "switch_min_frame_size":
+            IxnetworkIxiaClientImpl.ixnet.Traffic.EnableMinFrameSize = kwarg["params"][0].get("enable_min_size", True)
+        return 0, ""
+
+    def format_switch_min_frame_size(self, command, *argv, **kwarg):
+        return command
+    
+    def parse_switch_min_frame_size(self, command, *argv, **kwarg):
+        return command
 
     @classmethod
     def __convert_to_ixia_speed(self, speed, duplex):

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -100,6 +100,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                                    "igmpv2", "igmpv3MembershipQuery", "igmpv3MembershipReport")
             }
 
+            IxnetworkIxiaClientImpl.ixnet.Traffic.EnableMinFrameSize = True
             device.applog.info("Connection to Ixia REST API Server Established")
             ixia_ports = param["tgen_ports"]
             swp_ports = param["swp_ports"]

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
@@ -28,7 +28,8 @@ class TrafficGen(TestLibObject):
             send_ping - [port, dst_ip, src_ip]
             send_arp - [port, src_ip]
             clear_traffic - [traffic_names]
-            update_l1_config - ['speed', 'autoneg', 'tgen_ports']
+            update_l1_config - ['speed', 'autoneg', 'ixia_ports']
+            switch_min_frame_size - [enable_min_size]
         
     """
     async def _run_command(api, *argv, **kwarg):
@@ -558,4 +559,24 @@ class TrafficGen(TestLibObject):
         
         """
         return await TrafficGen._run_command("update_l1_config", *argv, **kwarg)
+        
+    async def switch_min_frame_size(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.switch_min_frame_size(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'enable_min_size':'bool',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+          switch_min_frame_size - ['enable_min_size']
+        
+        """
+        return await TrafficGen._run_command("switch_min_frame_size", *argv, **kwarg)
         


### PR DESCRIPTION
- Added options (Use 4 Byte Signature) to test traffic with smaller frame sizes. 
- Update files: _ixnetwork_ixia_client.py, ixnetwork_ixia_client_impl.py, tgen_utils.py, traffic.yaml, ixia.yaml, traffic_gen.py_