### PR TITLE
Add ipv6 support

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -102,6 +102,7 @@ def tgen_utils_dev_groups_from_config(config):
             "gw": peer ip,
             "plen": prefix length,
             "vlan": vlan id to be configured (optional),
+            "version": [ ipv4 | ipv6 ] (default is ipv4)
         },
         ...
     ]
@@ -117,6 +118,7 @@ def tgen_utils_dev_groups_from_config(config):
             "gw": el["gw"],
             "plen": el["plen"],
             "vlan": el.get("vlan", None),
+            "version": el.get("version", "ipv4"),
         })
     return dev_groups
 
@@ -742,4 +744,34 @@ async def tgen_utils_send_arp(device, config):
     ]}])
     if out[0][device.host_name]["rc"] != 0:
         device.applog.warning(f"Some arps did not reach their destination\n{out}")
+    return out[0][device.host_name]["result"]
+
+
+async def tgen_utils_send_ns(device, config):
+    """
+    - Sends NS packets from TG ports to DUT
+    - Expects config to be a list of dicts:
+    [
+        {
+            "ixp": tgen port,
+            "src_ip": tgen port ip (optional),
+        },
+        ...
+    ]
+    - returns a list of dicts for each NS sent
+    [
+        {
+            "success": True or False,
+            "port": tg_port,
+            "src_ip": tg_port ip,
+        },
+        ...
+    ]
+    """
+    out = await TrafficGen.send_ns(input_data=[{device.host_name: [
+        {"port": ns["ixp"], "src_ip": ns["src_ip"] if "src_ip" in ns else None}
+        for ns in config
+    ]}])
+    if out[0][device.host_name]["rc"] != 0:
+        device.applog.warning(f"Some NSs did not reach their destination\n{out}")
     return out[0][device.host_name]["result"]

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/dent/traffic/traffic.yaml
@@ -39,7 +39,8 @@
            'load_config', 'save_config',
            'set_traffic', 'start_traffic', 'stop_traffic', 'get_stats', 'clear_stats',
            'start_protocols', 'stop_protocols', 'set_protocol', 'get_protocol_stats',
-           'clear_protocol_stats', 'send_arp', 'send_ping', 'clear_traffic', 'get_drilldown_stats']
+           'clear_protocol_stats', 'send_arp', 'send_ns', 'send_ping', 'clear_traffic',
+           'get_drilldown_stats']
     members:
     - name: client_addr
       type: ip_addr_t

--- a/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
+++ b/DentOS_Framework/DentOsTestbedLib/gen/model/traffic/ixia/ixia.yaml
@@ -21,6 +21,7 @@
           clear_protocol_stats - [protocols]
           send_ping - [port, dst_ip, src_ip]
           send_arp - [port, src_ip]
+          send_ns - [port, src_ip]
           clear_traffic - [traffic_names]
      implements: "dent:traffic:traffic_gen"
      platforms: ['ixnetwork']
@@ -69,9 +70,10 @@
         desc: |
          - IxiaClient
            send_ping - [port, dst_ip, src_ip]
-      - name: send_arp
-        apis: ['send_arp']
+      - name: resolve_neighbor
+        apis: ['send_arp', 'send_ns']
         params: ['ports', 'src_ip']
         desc: |
          - IxiaClient
            send_arp - [port, src_ip]
+           send_ns - [port, src_ip]

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client.py
@@ -24,6 +24,7 @@ class IxnetworkIxiaClient(TestLibObject):
             clear_protocol_stats - [protocols]
             send_ping - [port, dst_ip, src_ip]
             send_arp - [port, src_ip]
+            send_ns - [port, src_ip]
             clear_traffic - [traffic_names]
         
     """
@@ -72,13 +73,13 @@ class IxnetworkIxiaClient(TestLibObject):
     def parse_send_ping(self, command, output, *argv, **kwarg):
         raise NotImplementedError
         
-    def format_send_arp(self, command, *argv, **kwarg):
+    def format_resolve_neighbor(self, command, *argv, **kwarg):
         raise NotImplementedError
         
-    def run_send_arp(self, device, command, *argv, **kwarg):
+    def run_resolve_neighbor(self, device, command, *argv, **kwarg):
         raise NotImplementedError
         
-    def parse_send_arp(self, command, output, *argv, **kwarg):
+    def parse_resolve_neighbor(self, command, output, *argv, **kwarg):
         raise NotImplementedError
         
     def format_command(self, command, *argv, **kwarg):
@@ -97,8 +98,8 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['send_ping']:
             return self.format_send_ping(command, *argv, **kwarg)
         
-        if command in ['send_arp']:
-            return self.format_send_arp(command, *argv, **kwarg)
+        if command in ['send_arp', 'send_ns']:
+            return self.format_resolve_neighbor(command, *argv, **kwarg)
         
         
         raise NameError("Cannot find command "+command)
@@ -119,8 +120,8 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['send_ping']:
             return self.run_send_ping(device_obj, command, *argv, **kwarg)
         
-        if command in ['send_arp']:
-            return self.run_send_arp(device_obj, command, *argv, **kwarg)
+        if command in ['send_arp', 'send_ns']:
+            return self.run_resolve_neighbor(device_obj, command, *argv, **kwarg)
         
         
         print (len(command))
@@ -142,8 +143,8 @@ class IxnetworkIxiaClient(TestLibObject):
         if command in ['send_ping']:
             return self.parse_send_ping(command, output, *argv, **kwarg)
         
-        if command in ['send_arp']:
-            return self.parse_send_arp(command, output, *argv, **kwarg)
+        if command in ['send_arp', 'send_ns']:
+            return self.parse_resolve_neighbor(command, output, *argv, **kwarg)
         
         
         raise NameError("Cannot find command "+command)

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -94,6 +94,10 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             IxnetworkIxiaClientImpl.tis = []
             crc = IxnetworkIxiaClientImpl.ixnet.Traffic.TrafficItem.ConfigElement._SDM_ENUM_MAP["crc"]
             IxnetworkIxiaClientImpl.bad_crc = {True: crc[0], False: crc[1]}
+            IxnetworkIxiaClientImpl.stack_template = {
+                stack_type: IxnetworkIxiaClientImpl.ixnet.Traffic.ProtocolTemplate.find(StackTypeId=f"^{stack_type}$")
+                for stack_type in ("ipv4", "ipv6", "vlan", "ethernet", "tcp", "udp", "icmpv1", "icmpv2")
+            }
 
             device.applog.info("Connection to Ixia REST API Server Established")
             ixia_ports = param["tgen_ports"]
@@ -121,37 +125,49 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                     device.applog.info("Changing all vports media mode to copper")
                     vport[0].L1Config.NovusTenGigLan.Media = "copper"
 
-                device.applog.info("Adding Ipv4 on ixia port {} swp {}".format(port, vport[1]))
+                device.applog.info("Adding interface on ixia port {} swp {}".format(port, vport[1]))
                 topo = IxnetworkIxiaClientImpl.ixnet.Topology.add(Vports=vport[0])
                 for dev in dev_groups[port]:
                     device.applog.info("Adding device {}".format(dev))
+                    is_ipv6 = dev.get("version", "ipv4") == "ipv6"
                     dev_group = topo.DeviceGroup.add(Multiplier=dev.get("count", 2))
                     if "vlan" in dev and dev["vlan"] is not None:
                         eth = dev_group.Ethernet.add(Name=vport[1], UseVlans=True, VlanCount=1)
                         eth.Vlan.find()[0].VlanId.Single(dev["vlan"])
                     else:
                         eth = dev_group.Ethernet.add(Name=vport[1])
-                    ep = eth.Ipv4.add(Name=dev["name"])
-                    ep.Address.Increment(dev["ip"], "0.0.0.1")
+                    if is_ipv6:
+                        ep = eth.Ipv6.add(Name=dev["name"])
+                        ep.Address.Increment(dev["ip"], "::1")
+                    else:
+                        ep = eth.Ipv4.add(Name=dev["name"])
+                        ep.Address.Increment(dev["ip"], "0.0.0.1")
                     ep.GatewayIp.Single(dev["gw"])
                     ep.Prefix.Single(dev["plen"])
                     if dev.get("bgp_peer", {}):
                         bp = dev["bgp_peer"]
-                        bgp_ep = ep.BgpIpv4Peer.add(Name=dev["name"])
+                        if is_ipv6:
+                            bgp_ep = ep.BgpIpv6Peer.add(Name=dev["name"])
+                        else:
+                            bgp_ep = ep.BgpIpv4Peer.add(Name=dev["name"])
                         bgp_ep.DutIp.Single(dev["gw"])
                         bgp_ep.Type.Single("external")
                         bgp_ep.LocalAs2Bytes.Single(bp["local_as"])
                         bgp_ep.HoldTimer.Single(bp["hold_timer"])
                         bgp_ep.UpdateInterval.Single(bp["update_interval"])
-                        # "route_ranges": [{"number_of_routes": 100, "first_route": f"{br_ip}.0.0.1",},],
                         ng = dev_group.NetworkGroup.add(
                             Multiplier=len(bp["route_ranges"]), Name=dev["name"]
                         )
                         ng.Enabled.Single(True)
                         for rr in bp["route_ranges"]:
-                            pool = ng.Ipv4PrefixPools.add(
-                                Name=dev["name"], NumberOfAddresses=rr["number_of_routes"]
-                            )
+                            if is_ipv6:
+                                pool = ng.Ipv6PrefixPools.add(
+                                    Name=dev["name"], NumberOfAddresses=rr["number_of_routes"]
+                                )
+                            else:
+                                pool = ng.Ipv4PrefixPools.add(
+                                    Name=dev["name"], NumberOfAddresses=rr["number_of_routes"]
+                                )
                             pool.NetworkAddress.Single(rr["first_route"])
                             IxnetworkIxiaClientImpl.rr_eps.append(pool)
 
@@ -276,7 +292,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             raise ValueError(f"Unable to set {value} for field {field.Name}")
         field.Auto = False
         field.update(**param)
-
+    
     def __update_frame_rate(self, config_element, pkt_data):
         """
         Update frame rate type and frame rate from pkt_data
@@ -295,180 +311,147 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             Rate=pkt_data.get("rate", "100"),
         )
 
-    def set_l4_traffic(self, config_element, ipv4_stack, pkt_data):
-        if "ipproto" not in pkt_data:
-            return
-        if pkt_data["ipproto"] not in ["tcp", "udp", "icmpv1", "icmpv2"]:
-            return
-        ipproto_template = IxnetworkIxiaClientImpl.ixnet.Traffic.ProtocolTemplate.find(
-            StackTypeId="^{}$".format(pkt_data["ipproto"])
-        )
-        l4_stack = config_element.Stack.read(ipv4_stack.AppendProtocol(ipproto_template))
-        if "dstPort" in pkt_data:
-            if ":" in pkt_data["dstPort"]:
-                start, step, count = pkt_data["dstPort"].split(":")
-                value = {"type": "increment", "start": start, "step": step, "count": count}
-            else:
-                value = pkt_data["dstPort"]
-            self.__update_field(l4_stack.Field.find(FieldTypeId=f"{pkt_data['ipproto']}.header.dstPort"),
-                                value)
-        if "srcPort" in pkt_data:
-            self.__update_field(l4_stack.Field.find(FieldTypeId=f"{pkt_data['ipproto']}.header.srcPort"),
-                                pkt_data["srcPort"])
-
-        if "icmpType" in pkt_data:
-            self.__update_field(l4_stack.Field.find(FieldTypeId=f"{pkt_data['ipproto']}.message.messageType"),
-                                pkt_data["icmpType"])
-        if "icmpCode" in pkt_data:
-            self.__update_field(l4_stack.Field.find(FieldTypeId=f"{pkt_data['ipproto']}.message.codeValue"),
-                                pkt_data["icmpCode"])
-
-    def set_ethernet_traffic(self, device, name, pkt_data, traffic_type):
-        # create an ipv4 traffic item
-        ipv4_template = IxnetworkIxiaClientImpl.ixnet.Traffic.ProtocolTemplate.find(
-            StackTypeId="^ipv4$"
-        )
-        vlan_template = IxnetworkIxiaClientImpl.ixnet.Traffic.ProtocolTemplate.find(
-            StackTypeId="^vlan$"
-        )
-        for ip1, ep1, rep1 in zip(
-            IxnetworkIxiaClientImpl.ip_eps,
-            IxnetworkIxiaClientImpl.eth_eps,
-            IxnetworkIxiaClientImpl.raw_eps,
-        ):
-            if "ip_source" in pkt_data and ip1.Name not in pkt_data["ip_source"]:
+    @classmethod
+    def __create_traffic_items(cls, device, pkt_data, name):
+        traffic_type = pkt_data.get("type", "ipv4")
+        if traffic_type == "ethernet":
+            traffic_type = "ethernetVlan"
+        for ip1, ep1, rep1, rr1 in zip(cls.ip_eps, cls.eth_eps, cls.raw_eps, cls.rr_eps):
+            if any(src in pkt_data and endpoint.Name not in pkt_data[src]
+                   for src, endpoint in (("ip_source", ip1), ("ep_source", ep1), ("bgp_source", rr1))):
                 continue
-            if "ep_source" in pkt_data and ep1.Name not in pkt_data["ep_source"]:
-                continue
-            device.applog.info("Creating the Ethernet traffic stream on {}".format(ep1.Name))
-            ti = IxnetworkIxiaClientImpl.ixnet.Traffic.TrafficItem.add(
+            device.applog.info(f"Creating {traffic_type} traffic stream")
+            ti = cls.ixnet.Traffic.TrafficItem.add(
                 Name=name, TrafficType=traffic_type
             )
             ep_count = 0
-            for ip2, ep2, rep2 in zip(
-                IxnetworkIxiaClientImpl.ip_eps,
-                IxnetworkIxiaClientImpl.eth_eps,
-                IxnetworkIxiaClientImpl.raw_eps,
-            ):
+            for ip2, ep2, rep2, rr2 in zip(cls.ip_eps, cls.eth_eps, cls.raw_eps, cls.rr_eps):
                 if ep1 == ep2:
                     continue
-                if "ip_destination" in pkt_data and ip2.Name not in pkt_data["ip_destination"]:
+                if any(dst in pkt_data and endpoint.Name not in pkt_data[dst]
+                       for dst, endpoint in (("ip_destination", ip2),
+                                             ("ep_destination", ep2),
+                                             ("bgp_destination", rr2))):
                     continue
-                if "ep_destination" in pkt_data and ep2.Name not in pkt_data["ep_destination"]:
-                    continue
-                # create an endpoint set using the ipv4 objects
-                device.applog.info(
-                    "Adding the endpoint ep1 {} to ep2 {}".format(ep1.Name, ep2.Name)
-                )
-                if traffic_type == "raw":
-                    endpoint_set = ti.EndpointSet.add(Sources=rep1, Destinations=rep2)
-                else:
-                    endpoint_set = ti.EndpointSet.add(Sources=ep1, Destinations=ep2)
-                ep_count += 1
-            IxnetworkIxiaClientImpl.tis.append(ti)
-            track_by = {"trackingenabled0", "sourceDestValuePair0"}
-            ti.Enabled = True
-            self.__configure_egress_tracking(ti, pkt_data)
 
+                src_name, dst_name = None, None
+                if traffic_type in ("ipv4", "ipv6"):
+                    src, dst = ip1, ip2
+                elif traffic_type == "bgp":
+                    src, dst = rr1, rr2
+                elif traffic_type == "raw":
+                    src, dst = rep1, rep2
+                    src_name, dst_name = ep1.Name, ep2.Name
+                else:
+                    src, dst = ep1, ep2
+
+                if src_name is None and dst_name is None:
+                    src_name, dst_name = src.Name, dst.Name
+                device.applog.info(f"Adding endpoint {src_name} to {dst_name}")
+
+                ti.EndpointSet.add(Sources=src, Destinations=dst)
+                ep_count += 1
+            cls.tis.append(ti)
+            ti.Enabled = True
+
+            yield ti, ep_count
+
+    def __configure_l2_stack(self, config_element, pkt_data, track_by):
+        eth_stack = config_element.Stack.find(StackTypeId="^ethernet$")
+
+        if "dstMac" in pkt_data:
+            self.__update_field(eth_stack.Field.find(FieldTypeId="ethernet.header.destinationAddress"),
+                                pkt_data["dstMac"])
+        if "srcMac" in pkt_data:
+            self.__update_field(eth_stack.Field.find(FieldTypeId="ethernet.header.sourceAddress"),
+                                pkt_data["srcMac"])
+        if "vlanID" in pkt_data:
+            vlan_stack = config_element.Stack.read(
+                eth_stack.AppendProtocol(self.stack_template["vlan"])
+            )
+            self.__update_field(vlan_stack.Field.find(FieldTypeId="vlan.header.vlanTag.vlanID"),
+                                pkt_data["vlanID"])
+            if "vlanPriority" in pkt_data:
+                self.__update_field(vlan_stack.Field.find(FieldTypeId="vlan.header.vlanTag.vlanUserPriority"),
+                                    pkt_data["vlanPriority"])
+            track_by.update(["vlanVlanId0", "vlanVlanUserPriority0"])
+            return vlan_stack
+        return eth_stack
+
+    def __configure_l3_stack(self, config_element, pkt_data, track_by, eth_stack):
+        if pkt_data.get("type") == "ipv6" or pkt_data.get("protocol") == "ipv6":
+            proto = "ipv6"
+            fields = {
+                "dstIp": "ipv6.header.dstIP",
+                "srcIp": "ipv6.header.srcIP",
+                "traffic_class": "ipv6.header.versionTrafficClassFlowLabel.trafficClass",
+            }
+        else:
+            proto = "ipv4"
+            fields = {
+                "dstIp": "ipv4.header.dstIp",
+                "srcIp": "ipv4.header.srcIp",
+                "dscp_ecn": "ipv4.header.priority.raw",
+                "ttl": "ipv4.header.ttl",
+            }
+
+        ip_stack = config_element.Stack.find(StackTypeId=f"^{proto}$")
+        if not len(ip_stack):
+            ip_stack = config_element.Stack.read(
+                eth_stack.AppendProtocol(self.stack_template[proto])
+            )
+        for key, field_type in fields.items():
+            if key not in pkt_data:
+                continue
+            if key == "dscp_ecn":
+                track_by.add("ipv4Raw0")
+            if key == "traffic_class":
+                track_by.add("ipv6Trafficclass0")
+            self.__update_field(ip_stack.Field.find(FieldTypeId=field_type),
+                                pkt_data[key])
+        return ip_stack
+
+    def __configure_l4_stack(self, config_element, pkt_data, track_by, ip_stack):
+        if "ipproto" not in pkt_data:
+            return
+        proto = pkt_data["ipproto"]
+        if proto not in ["tcp", "udp", "icmpv1", "icmpv2"]:
+            return
+
+        l4_stack = config_element.Stack.read(
+            ip_stack.AppendProtocol(self.stack_template[proto])
+        )
+        fields = {
+            "dstPort": f"{proto}.header.dstPort",
+            "srcPort": f"{proto}.header.srcPort",
+            "icmpType": f"{proto}.message.messageType",
+            "icmpCode": f"{proto}.message.codeValue",
+        }
+        for key, field_type in fields.items():
+            if key not in pkt_data:
+                continue
+            self.__update_field(l4_stack.Field.find(FieldTypeId=field_type),
+                                pkt_data[key])
+        return l4_stack
+
+    def set_traffic(self, device, name, pkt_data):
+        for ti, ep_count in self.__create_traffic_items(device, pkt_data, name):
+            track_by = {"trackingenabled0", "sourceDestValuePair0"}
             for ep in range(ep_count):
                 config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
                 self.__update_frame_rate(config_element, pkt_data)
                 config_element.FrameSize.update(
                     Type="fixed", FixedSize=pkt_data.get("frameSize", "512")
                 )
-                config_element.Crc = IxnetworkIxiaClientImpl.bad_crc[pkt_data.get("bad_crc", False)]
+                config_element.Crc = self.bad_crc[pkt_data.get("bad_crc", False)]
                 config_element.TransmissionControl.update(Type="continuous")
-                eth_stack = config_element.Stack.find(StackTypeId="^ethernet$")
-                if "vlanID" in pkt_data:
-                    vlan_stack = config_element.Stack.read(
-                        eth_stack.AppendProtocol(vlan_template)
-                    )
-                    ipv4_stack = config_element.Stack.read(vlan_stack.AppendProtocol(ipv4_template))
-                else:
-                    ipv4_stack = config_element.Stack.read(
-                        eth_stack.AppendProtocol(ipv4_template)
-                    )
-                if "dstMac" in pkt_data:
-                    self.__update_field(eth_stack.Field.find(FieldTypeId="ethernet.header.destinationAddress"),
-                                        pkt_data["dstMac"])
-                if "srcMac" in pkt_data:
-                    self.__update_field(eth_stack.Field.find(FieldTypeId="ethernet.header.sourceAddress"),
-                                        pkt_data["srcMac"])
-                if "vlanID" in pkt_data:
-                    self.__update_field(vlan_stack.Field.find(FieldTypeId="vlan.header.vlanTag.vlanID"),
-                                        pkt_data["vlanID"])
-                    if "vlanPriority" in pkt_data:
-                        self.__update_field(vlan_stack.Field.find(FieldTypeId="vlan.header.vlanTag.vlanUserPriority"),
-                                            pkt_data["vlanPriority"])
-                    track_by.update(["vlanVlanId0", "vlanVlanUserPriority0"])
-                if "dstIp" in pkt_data:
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.dstIp"),
-                                        pkt_data["dstIp"])
-                if "srcIp" in pkt_data:
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.srcIp"),
-                                        pkt_data["srcIp"])
-                if "dscp_ecn" in pkt_data:  # dscp and ecn
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.priority.raw"),
-                                        pkt_data["dscp_ecn"])
-                    track_by.add("ipv4Raw0")
-                if "ttl" in pkt_data:
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.ttl"),
-                                        pkt_data["ttl"])
-                self.set_l4_traffic(config_element, ipv4_stack, pkt_data)
-            ti.Tracking.find()[0].TrackBy = list(track_by)
+                eth_stack = self.__configure_l2_stack(config_element, pkt_data, track_by)
+                ip_stack = self.__configure_l3_stack(config_element, pkt_data, track_by, eth_stack)
+                self.__configure_l4_stack(config_element, pkt_data, track_by, ip_stack)
 
-    def set_ipv4_traffic(self, device, name, pkt_data, traffic_type):
-        # create an ipv4 traffic item
-        for ep1, rr_ep1 in zip(IxnetworkIxiaClientImpl.ip_eps, IxnetworkIxiaClientImpl.rr_eps):
-            if "bgp_source" in pkt_data and rr_ep1.Name not in pkt_data["bgp_source"]:
-                continue
-            if "ip_source" in pkt_data and ep1.Name not in pkt_data["ip_source"]:
-                continue
-            device.applog.info("Creating the IPV4 traffic stream on {}".format(ep1.Name))
-            ti = IxnetworkIxiaClientImpl.ixnet.Traffic.TrafficItem.add(
-                Name=name, TrafficType="ipv4"
-            )
-            ep_count = 0
-            for ep2, rr_ep2 in zip(IxnetworkIxiaClientImpl.ip_eps, IxnetworkIxiaClientImpl.rr_eps):
-                if ep1 == ep2:
-                    continue
-                if "bgp_destination" in pkt_data and rr_ep2.Name not in pkt_data["bgp_destination"]:
-                    continue
-                if "ip_destination" in pkt_data and ep2.Name not in pkt_data["ip_destination"]:
-                    continue
-                # create an endpoint set using the ipv4 objects
-                device.applog.info(
-                    "Adding the endpoint ep1 {} to ep2 {}".format(ep1.Name, ep2.Name)
-                )
-                if traffic_type == "ipv4":
-                    endpoint_set = ti.EndpointSet.add(Sources=ep1, Destinations=ep2)
-                else:
-                    endpoint_set = ti.EndpointSet.add(Sources=rr_ep1, Destinations=rr_ep2)
-                ep_count += 1
-            IxnetworkIxiaClientImpl.tis.append(ti)
-            track_by = {"trackingenabled0", "sourceDestValuePair0"}
-            ti.Enabled = True
+            ti.Tracking.find()[0].TrackBy = list(track_by)
             ti.BiDirectional = pkt_data.get("bi_directional", False)
             self.__configure_egress_tracking(ti, pkt_data)
-
-            for ep in range(ep_count):
-                config_element = ti.ConfigElement.find(EndpointSetId=ep + 1)
-                self.__update_frame_rate(config_element, pkt_data)
-                config_element.FrameSize.update(
-                    Type="fixed", FixedSize=pkt_data.get("frameSize", "512")
-                )
-                config_element.Crc = IxnetworkIxiaClientImpl.bad_crc[pkt_data.get("bad_crc", False)]
-                config_element.TransmissionControl.update(Type="continuous")
-                ipv4_stack = config_element.Stack.find(StackTypeId="^ipv4$")
-                if "dscp_ecn" in pkt_data:  # dscp and ecn
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.priority.raw"),
-                                        pkt_data["dscp_ecn"])
-                    track_by.add("ipv4Raw0")
-                if "ttl" in pkt_data:
-                    self.__update_field(ipv4_stack.Field.find(FieldTypeId="ipv4.header.ttl"),
-                                        pkt_data["ttl"])
-                self.set_l4_traffic(config_element, ipv4_stack, pkt_data)
-            ti.Tracking.find()[0].TrackBy = list(track_by)
 
     def run_traffic_item(self, device, command, *argv, **kwarg):
         """
@@ -489,23 +472,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             if not params or not params[0]:
                 return 0, "Need to specify the packet data"
             param = params[0]
-            type = param["pkt_data"].get("type", "ipv4")
-            if type == "ipv4":
-                self.set_ipv4_traffic(device, param["name"], param["pkt_data"], traffic_type="ipv4")
-            elif type == "bgp":
-                self.set_ipv4_traffic(device, param["name"], param["pkt_data"], traffic_type="bgp")
-            elif type == "ethernet":
-                self.set_ethernet_traffic(
-                    device, param["name"], param["pkt_data"], traffic_type="ethernetVlan"
-                )
-            elif type == "ethernetVlan":
-                self.set_ethernet_traffic(
-                    device, param["name"], param["pkt_data"], traffic_type="ethernetVlan"
-                )
-            elif type == "raw":
-                self.set_ethernet_traffic(
-                    device, param["name"], param["pkt_data"], traffic_type="raw"
-                )
+            self.set_traffic(device, name=param["name"], pkt_data=param["pkt_data"])
         elif command == "start_traffic":
             device.applog.info("Starting Traffic")
             IxnetworkIxiaClientImpl.ixnet.Traffic.Start()
@@ -568,7 +535,10 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             for ep in IxnetworkIxiaClientImpl.ip_eps:
                 device.applog.info("Sending ARP on " + ep.Name)
                 ep.Start()
-                ep.SendArp()
+                if "SendArp" in dir(ep):
+                    ep.SendArp()  # ipv4
+                else:
+                    ep.SendNs()  # ipv6
             time.sleep(5)
             device.applog.info("Generating Traffic")
             for ti in IxnetworkIxiaClientImpl.tis:
@@ -596,7 +566,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
     def format_send_ping(self, command, *argv, **kwarg):
         return command
 
-    def format_send_arp(self, command, *argv, **kwarg):
+    def format_resolve_neighbor(self, command, *argv, **kwarg):
         return command
 
     @classmethod
@@ -650,10 +620,11 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                       "src_ip": msg["src_ip"],
                       "dst_ip": msg["dst_ip"]} for msg in res]
 
-    def run_send_arp(self, device, command, *argv, **kwarg):
+    def run_resolve_neighbor(self, device, command, *argv, **kwarg):
         """
         - IxiaClient
            send_arp - [port, src_ip]
+           send_ns - [port, src_ip]
         """
         params = kwarg["params"]
         res = []
@@ -671,8 +642,12 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
                 out["arg2"] = False
                 device.applog.info(f"Did not find IP endpoint {port} with ip {src}")
             else:
-                device.applog.info(f"Sending ARP from {ip_ep.Name}")
-                out.update(ip_ep.SendArp()[0])
+                if command == "send_arp":
+                    device.applog.info(f"Sending ARP from {ip_ep.Name}")
+                    out.update(ip_ep.SendArp()[0])
+                elif command == "send_ns":
+                    device.applog.info(f"Sending NS from {ip_ep.Name}")
+                    out.update(ip_ep.SendNs()[0])
 
             res.append(out)
             if not out["arg2"]:

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/traffic_gen.py
@@ -432,9 +432,32 @@ class TrafficGen(TestLibObject):
         Description:
         - IxiaClient
           send_arp - [port, src_ip]
+          send_ns - [port, src_ip]
         
         """
         return await TrafficGen._run_command("send_arp", *argv, **kwarg)
+        
+    async def send_ns(*argv, **kwarg):
+        """
+        Platforms: ['ixnetwork']
+        Usage:
+        TrafficGen.send_ns(
+            input_data = [{
+                # device 1
+                'dev1' : [{
+                    # command 1
+                        'ports':'string_list',
+                        'src_ip':'ip_addr_t',
+                }],
+            }],
+        )
+        Description:
+        - IxiaClient
+          send_arp - [port, src_ip]
+          send_ns - [port, src_ip]
+        
+        """
+        return await TrafficGen._run_command("send_ns", *argv, **kwarg)
         
     async def send_ping(*argv, **kwarg):
         """


### PR DESCRIPTION
Add ability to assign IPv6 to Ixia ports.
Add ability to create IPv6 traffic.
Add SendNs function.
Update set_traffic function:
- instead of using 2 functions with duplicate code to create traffic there is only 1 now.
- the user can specify `type: ipv6` to create IPv6 traffic.
- the user can also specify `type: ethernet | raw` and `protocol: ipv6` to create ethernet/raw traffic with IPv6 header.
- old behavior is preserved.

```python

dev_groups = tgen_utils_dev_groups_from_config([
    {"ixp": tg_ports[0], "ip": "1.1.1.2", "gw": "1.1.1.1", "plen": 24},
    {"ixp": tg_ports[1], "ip": "2.2.2.2", "gw": "2.2.2.1", "plen": 24},
    {"ixp": tg_ports[2], "ip": "2001:1::2", "gw": "2001:1::1", "plen": 64, "version": "ipv6"},
    {"ixp": tg_ports[3], "ip": "2001:2::2", "gw": "2001:2::1", "plen": 64, "version": "ipv6"},
])
await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, ports, dev_groups)

streams = {
    f"ipv4": {
        "type": "ipv4",
        "ip_source": dev_groups[tg_ports[0]][0]["name"],
        "ip_destination": dev_groups[tg_ports[1]][0]["name"],
    },
    f"ipv6": {
        "type": "ipv6",
        "ip_source": dev_groups[tg_ports[2]][0]["name"],
        "ip_destination": dev_groups[tg_ports[3]][0]["name"],
    },
    f"ipv6 raw": {
        "type": "raw",
        "protocol": "ipv6",
        "ip_source": dev_groups[tg_ports[2]][0]["name"],
        "ip_destination": dev_groups[tg_ports[3]][0]["name"],
        "srcMac": "02:00:00:00:00:01",
        "dstMac": "02:00:00:00:00:02",
        "srcIp": "2001:1::5",
        "dstIp": "ff02::1",
    },
}
await tgen_utils_setup_streams(tgen_dev, None, streams)
```

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>