### PR TITLE
Add pytest-repeat plugin

### DIFF
--- a/DentOS_Framework/DentOsTestbed/Requirements.txt
+++ b/DentOS_Framework/DentOsTestbed/Requirements.txt
@@ -6,5 +6,6 @@ pexpect
 pytest
 pytest-asyncio
 pytest-html
+pytest-repeat
 ixnetwork_restpy
 pyvis == 0.1.9


### PR DESCRIPTION
Add `pytest-repeat` plugin which may help with running specific test cases specified amount of times. 
When running test case specify amount of repeats by adding `--count` argument to your command for running test case: 
`--count=3` - will rerun test case 3 times. 
