### PR TITLE
Add Lldp functional tests

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/constants.py
@@ -86,6 +86,7 @@ PYTEST_SUITES = {
     'suite_functional_table_size': 'Table size functional tests',
     'suite_functional_lacp': 'LACP functional tests',
     'suite_functional_ecmp': 'Ecmp functional tests',
+    'suite_functional_lldp': 'Lldp functional tests',
 }
 
 PYTEST_SUITE_GROUPS = {
@@ -137,5 +138,6 @@ PYTEST_SUITE_GROUPS = {
         'suite_functional_table_size',
         'suite_functional_lacp',
         'suite_functional_ecmp',
+        'suite_functional_lldp',
     ]
 }

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+import pytest_asyncio
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+)
+from dent_os_testbed.utils.test_utils.tb_utils import tb_device_check_services
+
+from dent_os_testbed.lib.lldp.lldp import Lldp
+from dent_os_testbed.lib.os.service import Service
+
+
+@pytest_asyncio.fixture()
+async def check_and_restore_lldp_service(testbed):
+    """
+    Check if lldp.service is running, start if it isnt running and restore default lldp settings
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 0)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dent_dev = dent_devices[0]
+    dev_name = dent_devices[0].host_name
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    service = 'lldpd.service'
+
+    try:
+        result = await tb_device_check_services(dent_dev, None, True, healthy_services=[service])
+        assert result.get(service).get('status') == 'running', \
+            f'Unexpected {service} status expected running actual {result.get(service).get("status")}'
+    except AssertionError:
+        out = await Service.restart(input_data=[{dev_name: [{'name': service}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to restart service {service}.\n{out}'
+
+    # Collect running LLDP configuration
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'running-configuration': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to show LLDP neighbors.\n{out}'
+    default_lldp_setup = out[0][dev_name]['parsed_output']['configuration']['config']
+    default_state = 'rx-and-tx'
+
+    yield
+
+    # Restore default LLDP settings
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': port, 'ports': '', 'lldp': '', 'status': default_state} for port in dut_ports]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports}.\n{out}'
+
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'running-configuration': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to show LLDP neighbors.\n{out}'
+    actual_lldp_setup = out[0][dev_name]['parsed_output']['configuration']['config']
+
+    if actual_lldp_setup['tx-delay'] != default_lldp_setup['tx-delay']:
+        out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'lldp': '', 'tx-interval': default_lldp_setup['tx-delay']}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to configure LLDP tx-interval.\n{out}'
+
+    if actual_lldp_setup['tx-hold'] != default_lldp_setup['tx-hold']:
+        out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'lldp': '', 'tx-hold': default_lldp_setup['tx-hold']}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to configure LLDP tx-hold.\n{out}'
+
+    if actual_lldp_setup['bond-slave-src-mac-type'] != default_lldp_setup['bond-slave-src-mac-type']:
+        out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'system': f'bond-slave-src-mac-type {default_lldp_setup["bond-slave-src-mac-type"]}'}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to configure LLDP tx-hold.\n{out}'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/lldp_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/lldp_utils.py
@@ -1,0 +1,278 @@
+from random import randint
+from ipaddress import IPv4Address
+from dent_os_testbed.lib.lldp.lldp import Lldp
+from dent_os_testbed.utils.test_utils.tb_utils import tb_device_tcpdump
+
+ERR_MSG_RX = 'Expected value {} for {} actual value {}'
+ERR_MSG_TX = 'Expected value {} for {} to be in {}'
+PORT_TYPE_MAP = {
+    1: 'ifalias',
+    3: 'mac',
+    5: 'ifname',
+}
+
+
+def random_mac():
+    return ':'.join(['02'] + [f'{randint(0, 255):02x}' for _ in range(5)])
+
+
+def get_lldp_stream(tx_port, rx_port, lldp, src_mac='aa:bb:cc:dd:ee:11', rate=2, size=512, count=6, name=1):
+    """
+    Generate Lldp stream
+    Args:
+        tx_port (str): Name of Tx port
+        rx_port (str): Name of Rx port
+        lldp (dict): Dict with lldp params to set
+        src_mac (str): Source MAC addr
+        rate (int): Rate of stream
+        size (int): Pkt size
+        count (int): Amount of pkts to send
+        name (int): Index to add to stream name
+    Returns:
+        Dict with lldp stream
+    """
+
+    stream = {f'lldp_{name}': {
+        'type': 'raw',
+        'protocol': 'lldp',
+        'ip_source': tx_port,
+        'ip_destination': rx_port,
+        'srcMac': src_mac,
+        'dstMac': '01:80:c2:00:00:0e',
+        'rate': rate,
+        'frameSize': size,
+        'transmissionControlType': 'fixedPktCount',
+        'frameCount': count,
+        **lldp,
+    }}
+    return stream
+
+
+def parse_lldp_pkt(tlvs, sniffed_out):
+    """
+    Parse sniffed lldp packet into dict with TLVs
+    Args:
+        tlvs (list): List with TLVs names
+        sniffed_out (str): Sniffed lldp packet
+    Returns:
+        Dict with TLVs names as key and parsed part of pkt as value
+    """
+    parsed = {}
+    sniffed = [i.strip() for i in sniffed_out.splitlines()]
+
+    for tlv in tlvs:
+        for line in sniffed:
+            if line.startswith(tlv):
+                result = []
+                index = sniffed.index(line) + 1
+                result.append(line)
+                while 'TLV' not in sniffed[index]:
+                    result.append(sniffed[index])
+                    index += 1
+                parsed[tlv] = ' '.join(result)
+                break
+    return parsed
+
+
+async def get_lldp_statistic(dev_name, port, stats='tx'):
+    """
+    Get lldp statistics from port
+    Args:
+        dev_name (str): Dut name
+        port (str): Dut port name
+        stats (str): Which stats to get tx/rx
+    Returns:
+        lldp statistic for port
+    """
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'interface': port, 'statistics': '', 'ports': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to show LLDP statistics.\n{out}'
+    return int(out[0][dev_name]['parsed_output']['lldp']['interface'][port][stats][stats])
+
+
+async def get_neighbors_info(dev_name, port):
+    """
+    Get lldp neighbors information
+    Args:
+        dev_name (str): Dut name
+        port (str): Dut port name
+    Returns:
+        Dict with lldp neighbor info
+    """
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'interface': port, 'neighbors': '', 'ports': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to show LLDP neighbors.\n{out}'
+    return out[0][dev_name]['parsed_output']['lldp']
+
+
+async def verify_rx_lldp_fields(dev_name, dut_port, chassis, port, port_type, ttl,
+                                sys_name=None, port_desc=None, sys_desc=None,
+                                mgmt_ip=None, capabilities=None):
+    """
+    Verify lldp neighbor info is as expected
+    Args:
+        dev_name (str): Dut name
+        dut_port (str): Dut port name
+        chassis (str): Expected chassis value
+        port (str): Expected port value
+        port_type (int): Expected port_type
+        ttl (int): Expected ttl value
+        sys_name (str): Expected system name
+        port_desc (str): Expected port description
+        sys_desc (str): Expected system description
+        mgmt_ip (str): Expected Managment ip address
+        capability (dict): Expected Capabilities
+    """
+    out = await get_neighbors_info(dev_name, port=dut_port)
+    chassis_info = out['interface'][dut_port]['chassis']
+    if sys_name:
+        chassis_info = out['interface'][dut_port]['chassis'][sys_name]
+    port_info = out['interface'][dut_port]['port']
+
+    assert chassis_info['id']['type'] == 'mac', ERR_MSG_RX.format('mac', 'chassis_type', chassis_info['id']['type'])
+    assert chassis_info['id']['value'] == chassis, ERR_MSG_RX.format(chassis, 'chassis', chassis_info['id']['value'])
+    assert port_info['id']['type'] == PORT_TYPE_MAP[port_type], ERR_MSG_RX.format(PORT_TYPE_MAP[port_type], 'port_type', port_info['id']['type'])
+    assert port_info['id']['value'] == port, ERR_MSG_RX.format(port, 'port', port_info['id']['value'])
+    assert int(port_info['ttl']) == ttl, ERR_MSG_RX.format(ttl, 'ttl', port_info['ttl'])
+
+    if port_desc:
+        assert port_info['descr'] == port_desc, ERR_MSG_RX.format(port_desc, 'port_desc', port_info['descr'])
+    if sys_name:
+        assert sys_name in list(out['interface'][dut_port]['chassis'].keys()), \
+            ERR_MSG_RX.format(sys_name, 'sys_name', out['interface'][dut_port]['chassis'].keys())
+    if sys_desc:
+        assert chassis_info['descr'] == sys_desc, ERR_MSG_RX.format(sys_desc, 'sys_desc', chassis_info['descr'])
+    if mgmt_ip:
+        assert chassis_info['mgmt-ip'] == mgmt_ip, ERR_MSG_RX.format(mgmt_ip, 'mgmt-ip', chassis_info['mgmt-ip'])
+    if capabilities:
+        res_capabilities = {capab['type']: capab['enabled'] for capab in chassis_info['capability']}
+        for cap, enabled in capabilities.items():
+            assert res_capabilities[cap] == enabled, \
+                ERR_MSG_RX.format(enabled, 'capabilities', res_capabilities[cap])
+
+
+async def verify_tx_lldp_fields(dev_name, dent_dev, port, interval, optional_tlvs=False):
+    """
+    Verify lldp pkts were transmitted and TLVs are as configured on DUT
+    Args:
+        dev_name (str): Dut name
+        dent_dev (object): Dut object
+        port (str): Dut port name
+        interval (int): Timeout to sniff lldp pkt
+        optional_tlvs (bool): If True check both mandatory and optional TLVs
+    """
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'interfaces': '', 'interface': port, 'ports': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to LLDP port info.\n{out}'
+    lldp_info = out[0][dev_name]['parsed_output']['lldp']['interface'][port]
+
+    _, out = await dent_dev.run_cmd('uname -n')
+    sys_name = out.strip()
+
+    chassis_info = lldp_info['chassis'][sys_name]['id']
+    port_info = lldp_info['port']['id']
+    ttl = lldp_info['ttl']['ttl']
+
+    res = await tb_device_tcpdump(dent_dev, port, 'ether proto 0x88cc -vnne', timeout=interval + 1, dump=True)
+    mandatory_tlvs = ['Chassis ID TLV', 'Port ID TLV', 'Time to Live TLV']
+    optional_tlvs = ['System Name TLV', 'System Description TLV', 'System Capabilities TLV',
+                     'Management Address TLV', 'Port Description TLV']
+    tlvs = mandatory_tlvs if not optional_tlvs else mandatory_tlvs + optional_tlvs
+    parsed_lldp = parse_lldp_pkt(tlvs, res)
+
+    assert f'Subtype {chassis_info["type"].upper()}' in parsed_lldp[tlvs[0]], \
+        ERR_MSG_TX.format(chassis_info['type'].upper(), 'Chassis TLV Subtype', parsed_lldp[tlvs[0]])
+    assert chassis_info['value'] in parsed_lldp[tlvs[0]], \
+        ERR_MSG_TX.format(chassis_info['value'], 'Chassis TLV Value', parsed_lldp[tlvs[0]])
+    assert f'Subtype {port_info["type"].upper()}' in parsed_lldp[tlvs[1]], \
+        ERR_MSG_TX.format(port_info['type'].upper(), 'Port TLV Subtype', parsed_lldp[tlvs[1]])
+    assert port_info['value'] in parsed_lldp[tlvs[1]], \
+        ERR_MSG_TX.format(port_info['value'], 'Port TLV Value', parsed_lldp[tlvs[1]])
+    assert str(ttl) in parsed_lldp[tlvs[2]], \
+        ERR_MSG_TX.format(str(ttl), tlvs[2], parsed_lldp[tlvs[2]])
+
+    if optional_tlvs:
+        system_name = list(lldp_info['chassis'].keys())
+        sys_descr = lldp_info['chassis'][sys_name]['descr']
+        port_descr = lldp_info['port']['descr']
+        capability = lldp_info['chassis'][sys_name]['capability']
+        mgmt = lldp_info['chassis'][sys_name]['mgmt-ip']
+
+        assert system_name[0] in parsed_lldp[optional_tlvs[0]], ERR_MSG_TX.format(system_name[0], optional_tlvs[0], parsed_lldp[optional_tlvs[0]])
+        assert sys_descr in parsed_lldp[optional_tlvs[1]], ERR_MSG_TX.format(sys_descr, optional_tlvs[1], parsed_lldp[optional_tlvs[1]])
+        for cap in capability:
+            cap_name = cap['type'].upper() if cap['type'] == 'Wlan' else cap['type']
+            assert cap_name in parsed_lldp[optional_tlvs[2]], ERR_MSG_TX.format(cap_name, optional_tlvs[2], parsed_lldp[optional_tlvs[2]])
+
+            if cap['enabled']:
+                assert cap_name in parsed_lldp[optional_tlvs[2]].split('Enabled Capabilities')[-1], \
+                    ERR_MSG_TX.format(cap_name, 'System Enabled Capabilities', parsed_lldp[optional_tlvs[2]].split('Enabled Capabilities')[-1])
+
+        assert mgmt[0] in parsed_lldp[optional_tlvs[3]], \
+            ERR_MSG_TX.format(mgmt[0], optional_tlvs[3], parsed_lldp[optional_tlvs[3]])
+        assert port_descr in parsed_lldp[optional_tlvs[4]], \
+            ERR_MSG_TX.format(port_descr, optional_tlvs[4], parsed_lldp[optional_tlvs[4]])
+
+
+def build_lldp_optional_pkt(chassis, port, ttl, port_desc=None, sys_name=None,
+                            sys_desc=None, capability=None, enabled_capability=None,
+                            mgmt_ip=None):
+    """
+    Build an hex output of lldp packet with optional fields
+    Args:
+        chassis (str): Chassis Mac address
+        port (str): Port Mac address
+        ttl (int): Ttl value to set
+        port_desc (str): Port description
+        sys_name (str): System name
+        sys_desc (str): System description
+        capability (int): Capabilities value to set (will be converted to hex)
+        enabled_capability (int): Enabled capabilities value to set (will be converted to hex)
+        mgmt_ip (str): Managment ip address to advertise
+    Returns:
+        String which contains hex representation of lldp pkt
+    """
+    lldp_mandatory = '02{chassis_len}04{chassis}04{port_len}03{port}0602{ttl}'
+    lldp_optional = ''
+
+    # Mandatory Fields
+    chassis_len = hex(len(chassis.replace(':', '')) // 2 + 1)[2:].zfill(2)
+    chassis_var = chassis.replace(':', '')
+    port_len = hex(len(port.replace(':', '')) // 2 + 1)[2:].zfill(2)
+    port_var = port.replace(':', '')
+    ttl = hex(ttl)[2:].zfill(4)
+
+    # Optional Fields
+    if port_desc:
+        port_description = port_desc.encode().hex()
+        port_desc_len = hex(len(port_description) // 2)[2:]
+        port_desc = port_description
+        lldp_optional += ''.join(['08', port_desc_len, port_desc])
+    if sys_name:
+        system_name = sys_name.encode().hex()
+        sys_name_len = hex(len(system_name) // 2)[2:].zfill(2)
+        sys_name = system_name
+        lldp_optional += ''.join(['0A', sys_name_len, sys_name])
+    if sys_desc:
+        system_description = sys_desc.encode().hex()
+        sys_desc_len = hex(len(system_description) // 2)[2:]
+        sys_desc = system_description
+        lldp_optional += ''.join(['0C', sys_desc_len, sys_desc])
+    if capability and enabled_capability:
+        capability = hex(capability)[2:].zfill(4)
+        enabled_capability = hex(enabled_capability)[2:].zfill(4)
+        lldp_optional += ''.join(['0E04', capability, enabled_capability])
+    if mgmt_ip:
+        mgmt_ip = IPv4Address(mgmt_ip).packed.hex()
+        lldp_optional += ''.join(['100C0501', mgmt_ip, '02000186A000'])
+
+    lldp_mandatory = lldp_mandatory.format(chassis_len=chassis_len,
+                                           chassis=chassis_var,
+                                           port_len=port_len,
+                                           port=port_var,
+                                           ttl=ttl)
+
+    return lldp_mandatory + lldp_optional + '0000'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_receive.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_receive.py
@@ -1,0 +1,333 @@
+import pytest
+import asyncio
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.lldp.lldp import Lldp
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+)
+
+from dent_os_testbed.test.test_suite.functional.lldp.lldp_utils import (
+    get_lldp_stream, get_neighbors_info,
+    verify_rx_lldp_fields,
+    get_lldp_statistic,
+    build_lldp_optional_pkt,
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_lldp,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures('check_and_restore_lldp_service', 'cleanup_tgen'),
+]
+
+
+@pytest.mark.parametrize('scenario', ['basic', 'mandatory', 'optional', 'ttl'])
+async def test_lldp_received(testbed, scenario):
+    """
+    Test Name: test_lldp_received
+    Test Suite: suite_functional_lldp
+    Test Overview: Test lldp received in different scenarios
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Enable first DUT port to recieve lldp units
+    3. Setup lldp packet for trasmitting to first DUT port
+       In case of ttl scenario set ttl to 20
+    4. Transmit lldp packet to first DUT port
+    5. Verifying lldp packet have been received on first DUT port
+       basic: Verify that DUT received lldp packet based on port rx stats
+       mandatory: Verify that DUT learned lldp neighbour and have all mandatory TLVs as expected
+       ttl: Verify that DUT learned lldp neighbour and have all mandatory TLVs as expected,
+            and that after sleep of ttl time neighbour will be absent
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    count = 6
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}
+         ])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 2.Enable first DUT port to recieve lldp units
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'rx-only'}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+
+    # 3.Setup lldp packet for trasmitting to first DUT port
+    # In case of ttl scenario set ttl to 20
+    chassis = '00:19:2f:a7:b2:8d'
+    port = 'Uplink to Spine 1'
+    port_subtype = 1
+    ttl = 120
+    lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port.encode().hex()) // 2) + 1,
+            'portSubtype': port_subtype,
+            'portVarLen': len(port.encode().hex()) // 2,
+            'portId': port.encode().hex(),
+            'ttlLen': 2,
+            'ttlVal': ttl,
+    }
+    if scenario == 'ttl':
+        chassis = '00:00:00:11:11:11'
+        port = '00:00:00:00:00:07'
+        ttl = 20
+        port_subtype = 3
+        lldp.update({
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port.replace(':', '')) // 2) + 1,
+            'portSubtype': port_subtype,
+            'portVarLen': len(port.replace(':', '')) // 2,
+            'portId': port.replace(':', ''),
+            'ttlVal': ttl,
+        })
+    elif scenario == 'optional':
+        port = '00:02:03:00:00:07'
+        port_desc = 'GigabitEthernet8'
+        sys_name = 'S2.cisco.com'
+        sys_desc = 'Cisco IOS Software, C3560 Software (C3560-ADVIPSERVICESK9-M), Version 12.2(44)SE, RELEASE SOFTWARE (fc1)'
+        mgmt = '10.5.225.52'
+        capabilities = {'Bridge': True, 'Router': False}
+        lldp_hex = build_lldp_optional_pkt(chassis, port, ttl, port_desc=port_desc, sys_name=sys_name,
+                                           sys_desc=sys_desc, capability=20, enabled_capability=4, mgmt_ip=mgmt)
+
+        lldp_stream = {'lldp_optional': {
+            'type': 'custom',
+            'protocol': '88cc',
+            'ip_source': dev_groups[tg_ports[0]][0]['name'],
+            'ip_destination': dev_groups[tg_ports[1]][0]['name'],
+            'srcMac': 'aa:bb:cc:dd:ee:11',
+            'dstMac': '01:80:c2:00:00:0e',
+            'rate': 2,
+            'frameSize': 512,
+            'transmissionControlType': 'fixedPktCount',
+            'frameCount': 6,
+            'customLength': len(lldp_hex) // 2,
+            'customData': lldp_hex}
+        }
+    if scenario != 'optional':
+        lldp_stream = get_lldp_stream(dev_groups[tg_ports[0]][0]['name'], dev_groups[tg_ports[1]][0]['name'], lldp, count=count)
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=lldp_stream)
+
+    # Get lldp rx stats from port
+    rx_before = await get_lldp_statistic(dev_name, dut_ports[0], stats='rx')
+    # 4.Transmit lldp packet to first DUT port
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+
+    # 5.Verifying lldp packet have been received on first DUT port
+    if scenario in ['mandatory', 'ttl', 'optional']:
+        # mandatory: Verify that DUT learned lldp neighbour and have all mandatory TLVs as expected
+        # According to RFC 802.1AB there are 3 mandatory TLVs: chassisTlv, portTlv, ttlTlv
+        if scenario in ['mandatory', 'ttl']:
+            await verify_rx_lldp_fields(dev_name, dut_ports[0], chassis, port, port_subtype, ttl)
+
+            if scenario == 'ttl':
+                # Verify that after sleep of ttl time neighbour will be absent
+                await asyncio.sleep(ttl)
+                neighbor_info = await get_neighbors_info(dev_name, port=dut_ports[0])
+                assert not neighbor_info, f'lldp neighbout still exist.\n{out}'
+
+        elif scenario == 'optional':
+            await verify_rx_lldp_fields(dev_name, dut_ports[0], chassis, port, 3, ttl, sys_name=sys_name,
+                                        port_desc=port_desc, sys_desc=sys_desc, mgmt_ip=mgmt, capabilities=capabilities)
+
+    # basic: Verify that DUT received lldp packet based on port rx stats
+    elif scenario == 'basic':
+        rx_after = await get_lldp_statistic(dev_name, dut_ports[0], stats='rx')
+        assert rx_after == rx_before + count, f'rx_after {rx_after} != expected amount of pkts {rx_before + count}'
+
+
+@pytest.mark.parametrize('scenario', ['disable', 'port_down_up'])
+async def test_lldp_rx(testbed, scenario):
+    """
+    Test Name: test_lldp_rx
+    Test Suite: suite_functional_lldp
+    Test Overview: Test lldp received with port status disable/port down
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Set lldp status on first DUT port to disabled/port down and status rx-only
+    3. Setup lldp packet for trasmitting to first DUT port and transmit stream
+    4. Verifying lldp packet haven't been received on first DUT port
+       port_down_up scenario: Verify after port set up and resending traffic that lldp pkt will be received with all mandatory fields
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}
+         ])
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 2.Set lldp status on first DUT port to disabled/port down and status rx-only
+    if scenario == 'disable':
+        out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'disabled'}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+
+    elif scenario == 'port_down_up':
+        out = await IpLink.set(
+            input_data=[{dev_name: [
+                {'device': dut_ports[0], 'operstate': 'down'}]}])
+        assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'DOWN' state.\n{out}"
+
+        out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'rx-only'}]}])
+        assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+
+    # 3.Setup lldp packet for trasmitting to first DUT port and transmit stream
+    chassis = 'a2:2c:38:b8:9c:a6'
+    port = 'Ethernet0/13'
+    ttl = 120
+    port_subtype = 5
+    lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port.encode().hex()) // 2) + 1,
+            'portSubtype': port_subtype,
+            'portVarLen': len(port.encode().hex()) // 2,
+            'portId': port.encode().hex(),
+            'ttlLen': 2,
+            'ttlVal': ttl
+    }
+    lldp_stream = get_lldp_stream(dev_groups[tg_ports[0]][0]['name'], dev_groups[tg_ports[1]][0]['name'], lldp)
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=lldp_stream)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+
+    # 4.Verifying lldp packet haven't been received on first DUT port
+    neighbor_info = await get_neighbors_info(dev_name, port=dut_ports[0])
+    assert not neighbor_info, f'LLDP neighbout still exist.\n{out}'
+
+    # port_down_up scenario: Verify after port set up and resending traffic that lldp pkt will be received with all mandatory fields
+    if scenario == 'port_down_up':
+        out = await IpLink.set(
+            input_data=[{dev_name: [
+                {'device': dut_ports[0], 'operstate': 'up'}]}])
+        assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+        await tgen_utils_start_traffic(tgen_dev)
+        await asyncio.sleep(10)
+        await verify_rx_lldp_fields(dev_name, dut_ports[0], chassis, port, port_subtype, ttl)
+
+
+async def test_lldp_max_neighbours(testbed):
+    """
+    Test Name: test_lldp_max_neighbours
+    Test Suite: suite_functional_lldp
+    Test Overview: Verify that lldp will have amount of neighbours equal to max-neighbors configured in lldp
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Set lldp status on first DUT port rx-only, get max-neighbors configured in lldp
+    3. Setup incremented lldp packet for trasmitting to first DUT port and transmit stream
+    4. Verify that lldp will have configured amount of max-neighbors
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 2.Set lldp status on first DUT port rx-only, get max-neighbors configured in lldp
+    out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'rx-only'}]}])
+    assert not out[0][dev_name]['rc'], \
+        f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+
+    out = await Lldp.show_lldpcli(
+        input_data=[{dev_name: [
+            {'running-configuration': '', 'cmd_options': '-f json'}]}], parse_output=True)
+    assert not out[0][dev_name]['rc'], f'Failed to show LLDP neighbors.\n{out}'
+    max_neighbors = int(out[0][dev_name]['parsed_output']['configuration']['config']['max-neighbors'])
+
+    # 3.Setup incremented lldp packet for trasmitting to first DUT port and transmit stream
+    chassis = '01:01:01:01:01:01'
+    port_val = '02:02:02:02:02:02'
+    step = '00:00:00:00:00:10'
+    count = max_neighbors + 5
+
+    lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': {
+                'type': 'increment',
+                'start': chassis.replace(':', ''),
+                'step': step.replace(':', ''),
+                'count': count,
+            },
+            'portLen': (len(port_val.replace(':', '')) // 2) + 1,
+            'portSubtype': 3,
+            'portVarLen': len(port_val.replace(':', '')) // 2,
+            'portId': {
+                'type': 'increment',
+                'start': port_val.replace(':', ''),
+                'step': step.replace(':', ''),
+                'count': count,
+            },
+            'ttlLen': 2,
+            'ttlVal': 240,
+        }
+
+    lldp_stream = get_lldp_stream(dev_groups[tg_ports[0]][0]['name'], dev_groups[tg_ports[1]][0]['name'], lldp, rate=count, count=count)
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=lldp_stream)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+
+    # 4.Verify that lldp will have configured amount of max-neighbors
+    rc, out = await dent_dev.run_cmd('lldpcli show neighbors | grep RID | wc -l')
+    assert not rc, f'Failed to run cmd lldpcli show neighbors {rc}'
+    assert int(out.strip()) == max_neighbors, f'Current neighbors amount {int(out.strip())} is not equal to expected {max_neighbors}'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_transmit.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_transmit.py
@@ -1,0 +1,221 @@
+import pytest
+import asyncio
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.lldp.lldp import Lldp
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_traffic_generator_connect
+)
+
+from dent_os_testbed.utils.test_utils.tb_utils import tb_device_tcpdump
+from dent_os_testbed.test.test_suite.functional.lldp.lldp_utils import (
+    parse_lldp_pkt, get_lldp_statistic,
+    verify_tx_lldp_fields, ERR_MSG_TX
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_lldp,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures('check_and_restore_lldp_service', 'cleanup_tgen')
+]
+
+
+@pytest.mark.parametrize('scenario', ['basic', 'mandatory', 'optional'])
+async def test_lldp_transmitted(testbed, scenario):
+    """
+    Test Name: test_lldp_transmitted
+    Test Suite: suite_functional_lldp
+    Test Overview: Test Lldp transmitted with different scenarios
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Enable first DUT port to transmmit lldp units
+    3. Collect lldp units tx stats from first DUT port
+    4. Configure lldp tx-interval to 2 sec
+    5. Verify lldp unit was transmitted from DUT first port:
+       basic: Verify that lldp tx stats incremented
+       mandatory: Sniff and capture transmitted lldp packet, verify mandatory fields are as expected
+       optional: Sniff and capture transmitted lldp packet, verify mandatory and optional fields are as expected
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    lldp_interval = 2
+    wait_time = 3
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 2.Enable first DUT port to transmmit lldp units
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'tx-only'}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+    # 3.Collect lldp units tx stats from first DUT port
+    tx_before = await get_lldp_statistic(dev_name, dut_ports[0])
+
+    # 4.Configure lldp tx-interval to 2 sec
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'lldp': '', 'tx-interval': lldp_interval}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp tx-interval.\n{out}'
+
+    # 5.Verify lldp unit was transmitted from DUT first port
+    if scenario == 'basic':
+        # basic: Verify that lldp tx stats incremented
+        await asyncio.sleep(lldp_interval * wait_time)
+        tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+        assert tx_after >= tx_before + wait_time, f'tx_after {tx_after} != expected amount of pkts {tx_before + wait_time}'
+
+    elif scenario == 'mandatory':
+        # mandatory: Sniff and capture transmitted lldp packet, verify mandatory fields are as expected
+        await verify_tx_lldp_fields(dev_name, dent_dev, dut_ports[0], lldp_interval)
+
+    elif scenario == 'optional':
+        # optional: Sniff and capture transmitted lldp packet, verify mandatory and optional fields are as expected
+        await verify_tx_lldp_fields(dev_name, dent_dev, dut_ports[0], lldp_interval, optional_tlvs=True)
+
+
+@pytest.mark.parametrize('scenario', ['disabled', 'port_down', 'interval'])
+async def test_lldp_tx(testbed, scenario):
+    """
+    Test Name: test_lldp_tx
+    Test Suite: suite_functional_lldp
+    Test Overview: Test Lldp transmitted with different status scenarios
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Set first DUT port down in case of tx_port_down
+    3. Configure lldp status on first DUT port disabled/tx-only depending from scenario
+    4. Configure lldp tx-interval to 2 sec
+    5. Collect lldp units tx stats from first DUT port and sleep 6 sec
+    6. Verify that lldp pkts weren't transmitted from DUT first port in case of scenarios: port_down, disabled
+       port_down: Set first DUT port up, sleep interval time and verify that lldp pkt were sent from port
+       interval: Verify that lldp pkts were transmitted from port
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    lldp_interval = 2
+    wait_time = 3
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    status = 'disabled' if scenario == 'disabled' else 'tx-only'
+    # 2.Set first DUT port down in case of tx_port_down
+    if scenario == 'port_down':
+        out = await IpLink.set(
+            input_data=[{dev_name: [
+                {'device': dut_ports[0], 'operstate': 'down'}]}])
+        assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'DOWN' state.\n{out}"
+
+    # 3.Configure lldp status on first DUT port disabled/tx-only depending from scenario
+    # 4.Configure lldp tx-interval to 2 sec
+    out = await Lldp.configure(
+            input_data=[{dev_name: [
+                {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': status},
+                {'lldp': '', 'tx-interval': lldp_interval}]}])
+    assert not out[0][dev_name]['rc'], \
+        f'Failed to configure lldp status on port {dut_ports[0]} and tx-interval.\n{out}'
+
+    # 5.Collect lldp units tx stats from first DUT port and sleep 6 sec
+    tx_before = await get_lldp_statistic(dev_name, dut_ports[0])
+    await asyncio.sleep(lldp_interval * wait_time)
+
+    # 6.Verify that lldp pkts weren't transmitted from DUT first port
+    if scenario in ['disabled', 'port_down']:
+        tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+        assert tx_after == tx_before, f'tx_counter_after {tx_after} == tx_counters_before {tx_before}'
+
+        if scenario == 'port_down':
+            # tx_port_down: Set first DUT port up, sleep interval time and verify that lldp pkt were sent from port
+            out = await IpLink.set(
+                input_data=[{dev_name: [
+                    {'device': dut_ports[0], 'operstate': 'up'}]}])
+            assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+            await asyncio.sleep(lldp_interval * (wait_time + 2))
+            tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+            assert tx_after >= tx_before + wait_time, \
+                f'tx_counter_after {tx_after} >= tx_counters_before {tx_before + wait_time}'
+    else:
+        # tx_interval: Verify that lldp pkts were transmitted from port
+        tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+        assert tx_after >= tx_before + wait_time, f'tx_counter_after {tx_after} >= tx_counters_before {tx_before + wait_time}'
+
+
+async def test_lldp_tx_hold(testbed):
+    """
+    Test Name: test_lldp_tx_hold
+    Test Suite: suite_functional_lldp
+    Test Overview: Test Lldp pkt have modified ttl value after setting tx-hold
+    Test Procedure:
+    1. Init interfaces and set first DUT port up
+    2. Configure lldp status tx-only for first DUT port, tx-interval 2 sec and tx-hold 500 sec
+    3. Verify that transmitted lldp packet have ttl value set to tx-hold * tx-interval
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    lldp_interval = 2
+    tx_hold = 500
+
+    # 1.Init interfaces and set first DUT port up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'up'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 2.Configure lldp status tx-only for first DUT port, tx-interval 2 sec and tx-hold 500 sec
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'lldp': '', 'tx-hold': tx_hold},
+            {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'tx-only'},
+            {'lldp': '', 'tx-interval': lldp_interval}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status, tx-hold, tx-interval.\n{out}'
+
+    # 3.Verify that transmitted lldp packet have ttl value set to tx-hold * tx-interval
+    res = await tb_device_tcpdump(dent_dev, dut_ports[0], 'ether proto 0x88cc -vnne', timeout=lldp_interval + 1, dump=True)
+    parsed_lldp = parse_lldp_pkt(['Time to Live TLV'], res)
+    assert str(tx_hold * lldp_interval) in parsed_lldp['Time to Live TLV'], \
+        ERR_MSG_TX.format(str(tx_hold * lldp_interval), 'Time to Live TLV', parsed_lldp['Time to Live TLV'])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_tx_rx.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lldp/test_lldp_tx_rx.py
@@ -1,0 +1,344 @@
+import pytest
+import asyncio
+from random import randint
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.lldp.lldp import Lldp
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_dev_groups_from_config,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+)
+
+from dent_os_testbed.test.test_suite.functional.lldp.lldp_utils import (
+    get_lldp_stream, random_mac,
+    get_lldp_statistic,
+    verify_rx_lldp_fields,
+    verify_tx_lldp_fields,
+    get_neighbors_info
+)
+
+pytestmark = [
+    pytest.mark.suite_functional_lldp,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures('check_and_restore_lldp_service', 'cleanup_tgen')
+]
+
+
+@pytest.mark.usefixtures('cleanup_bridges')
+async def test_lldp_bridge(testbed):
+    """
+    Test Name: test_lldp_bridge
+    Test Suite: suite_functional_lldp
+    Test Overview: Test lldp transmitted and received with port in bridge
+    Test Procedure:
+    1. Create bridge device
+    2. Add 4 ports to bridge
+    3. Set bridge and first added port to up
+    4. Init interfaces
+    5. Configure lldp tx-interval to 2 sec
+    6. Collect tx stats and set first DUT port to lldp status rx-and-tx
+    7. Setup lldp packet for trasmitting to first DUT port and start sending
+    8. Verify lldp pkt received and mandatory fields are as expected
+    9. Verify lldp pkt's were transmitted with all fields set as expected
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    bridge = 'br0'
+    lldp_interval = 2
+    wait = 5
+
+    # 1.Create bridge device
+    out = await IpLink.add(
+        input_data=[{dev_name: [
+            {'device': bridge, 'type': 'bridge'}]}])
+    err_msg = f'Verify that bridge created and vlan filtering set successful\n{out}'
+    assert not out[0][dev_name]['rc'], err_msg
+    # 2.Add 4 ports to bridge
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'master': bridge} for port in dut_ports]}])
+    assert not out[0][dev_name]['rc'], f'Verify {dut_ports} set master to {bridge}.\n{out}'
+    # 3.Set bridge and first added port to up
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': device, 'operstate': 'up'} for device in [dut_ports[0], bridge]]}])
+    assert not out[0][dev_name]['rc'], f"Verify devices set to 'UP'.\n{out}"
+    # 4.Init interfaces
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[2], 'ip': '12.0.0.3', 'gw': '12.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[3], 'ip': '13.0.0.3', 'gw': '13.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+    # 5.Configure lldp tx-interval to 2 sec
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'lldp': '', 'tx-interval': lldp_interval}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp tx-interval {lldp_interval}.\n{out}'
+
+    # 6.Collect tx stats and set first DUT port to lldp status rx-and-tx
+    tx_before = await get_lldp_statistic(dev_name, dut_ports[0])
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'rx-and-tx'}]}])
+    assert not out[0][dev_name]['rc'], f'.\n{out}'
+
+    # 7.Setup lldp packet for trasmitting to first DUT port and start sending
+    chassis = 'a2:2c:38:b8:9c:a6'
+    port = 'Ethernet0/13'
+    ttl = 120
+    port_subtype = 5
+    lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port.encode().hex()) // 2) + 1,
+            'portSubtype': port_subtype,
+            'portVarLen': len(port.encode().hex()) // 2,
+            'portId': port.encode().hex(),
+            'ttlLen': 2,
+            'ttlVal': ttl,
+    }
+    lldp_stream = get_lldp_stream(dev_groups[tg_ports[0]][0]['name'], dev_groups[tg_ports[1]][0]['name'], lldp)
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=lldp_stream)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(lldp_interval * wait)
+
+    # 8.Verify lldp pkt received and mandatory fields are as expected
+    await verify_rx_lldp_fields(dev_name, dut_ports[0], chassis, port, port_subtype, ttl)
+
+    # 9.Verify lldp pkt's were transmitted with all fields set as expected
+    tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+    assert tx_after >= tx_before + wait, f'tx_after {tx_after} >= tx_before {tx_before}'
+    await verify_tx_lldp_fields(dev_name, dent_dev, dut_ports[0], lldp_interval, optional_tlvs=True)
+
+
+async def test_lldp_enable_disable_ports(testbed):
+    """
+    Test Name: test_lldp_enable_disable_ports
+    Test Suite: suite_functional_lldp
+    Test Overview: Test lldp transmitted and received with multiple ports set to lldp status rx-and-tx/disabled
+    Test Procedure:
+    1. Set 4 ports up and Init interfaces
+    2. Configure lldp tx-interval to 2 sec
+    3. Configure lldp ports to disabled/rx-and-tx state
+    4. Setup 4 lldp streams with different params and start transmitting traffic
+    5. Verify that ports with lldp status disabled won't transmit and receive lldp packets,
+       ports with status rx-and-tx transmitted and received lldp pkts
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 4)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    tx_interval = 2
+
+    # 1.Set 4 ports up and Init interfaces
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': port, 'operstate': 'up'} for port in dut_ports]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports} set to 'UP' state.\n{out}"
+
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': tg_ports[0], 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[2], 'ip': '12.0.0.3', 'gw': '12.0.0.1', 'plen': 24},
+         {'ixp': tg_ports[3], 'ip': '13.0.0.3', 'gw': '13.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+    # 2.Configure lldp tx-interval to 2 sec
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'lldp': '', 'tx-interval': tx_interval}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp tx-interval {tx_interval}.\n{out}'
+
+    # 3.Configure lldp ports to disabled/rx-and-tx state
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': port, 'ports': '', 'lldp': '', 'status': 'rx-and-tx' if indx % 2 else 'disabled'}
+            for indx, port in enumerate(dut_ports)]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports}.\n{out}'
+
+    # 4.Setup 4 lldp streams with different params and start transmitting traffic
+    lldps_verify = {}
+    streams = {}
+    for index, port in enumerate(dut_ports):
+        chassis = random_mac()
+        port_val = random_mac()
+        ttl = randint(160, 200)
+
+        lldps_verify.update({port: {
+            'chassis': chassis,
+            'port': port_val,
+            'ttl': ttl}
+        })
+        src = tg_ports[index]
+        dst = tg_ports[index ^ 1]
+        lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port_val.replace(':', '')) // 2) + 1,
+            'portSubtype': 3,
+            'portVarLen': len(port_val.replace(':', '')) // 2,
+            'portId': port_val.replace(':', ''),
+            'ttlLen': 2,
+            'ttlVal': ttl
+        }
+        lldp_stream = get_lldp_stream(dev_groups[src][0]['name'], dev_groups[dst][0]['name'], lldp, src_mac=random_mac(), name=index)
+        streams.update(lldp_stream)
+
+    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=streams)
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(10)
+
+    # 5.Verify that ports with lldp status disabled won't transmit and receive lldp packets,
+    #   ports with status rx-and-tx transmitted and recievd lldp pkts
+    for indx, port in enumerate(dut_ports):
+        tx_before = await get_lldp_statistic(dev_name, port)
+        neighbors = await get_neighbors_info(dev_name, port=port)
+
+        if not indx % 2:
+            assert port not in neighbors, f'Unexpected result, neighbour should be absent for {port}.\n{neighbors}'
+        else:
+            await verify_rx_lldp_fields(dev_name, port, lldps_verify[port]['chassis'],
+                                        lldps_verify[port]['port'], 3, lldps_verify[port]['ttl'])
+
+        await asyncio.sleep(tx_interval * 3)
+        tx_after = await get_lldp_statistic(dev_name, port)
+        if not indx % 2:
+            assert tx_before == tx_after, f'tx_after {tx_after} are not equal to tx_before before {tx_before}'
+        else:
+            assert tx_after >= tx_before + 3, f'tx_after {tx_after} are not >= tx_before counters {tx_before}'
+            await verify_tx_lldp_fields(dev_name, dent_dev, port, tx_interval, optional_tlvs=True)
+
+
+@pytest.mark.usefixtures('cleanup_bonds')
+async def test_lldp_lag(testbed):
+    """
+    Test Name: test_lldp_lag
+    Test Suite: suite_functional_lldp
+    Test Overview: Test lldp transmitted and received with port in lag
+    Test Procedure:
+    1. Create lag device and set first DUT port to down
+    2. Add first port from DUT to lag
+    3. Set first port DUT and lag device to up state
+    4. Init interfaces
+    5. Configure lldp tx-interval 2 sec, bond-slave-src-mac-type real and lldp status rx-and-tx
+    6. Setup lldp packet for trasmitting to first DUT port and start sending
+    7. Verify lldp pkt received and mandatory fields are as expected
+    8. Verify lldp pkt's were transmitted with all fields as expected
+    """
+
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [], 2)
+    if not tgen_dev or not dent_devices:
+        pytest.skip('The testbed does not have enough dent with tgen connections')
+    dev_name = dent_devices[0].host_name
+    dent_dev = dent_devices[0]
+    tg_ports = tgen_dev.links_dict[dev_name][0]
+    dut_ports = tgen_dev.links_dict[dev_name][1]
+    lldp_interval = 2
+    bond1 = 'bond1'
+    wait = 5
+
+    # 1.Create lag device and set first DUT port to down
+    out = await IpLink.add(
+        input_data=[{dev_name: [
+            {'name': bond1, 'type': 'bond', 'mode': '802.3ad'}]}])
+    err_msg = f'Verify that {bond1} was successfully added. \n{out}'
+    assert not out[0][dev_name]['rc'], err_msg
+
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'operstate': 'down'}]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} set to 'DOWN' state.\n{out}"
+
+    # 2.Add first port from DUT to lag
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dut_ports[0], 'master': bond1}]}])
+    err_msg = f'Verify that {dut_ports[0]} set to master .\n{out}'
+    assert not out[0][dev_name]['rc'], err_msg
+
+    # 3.Set first port DUT and lag device to up state
+    out = await IpLink.set(
+        input_data=[{dev_name: [
+            {'device': dev, 'operstate': 'up'} for dev in [dut_ports[0], bond1]]}])
+    assert not out[0][dev_name]['rc'], f"Verify {dut_ports[0]} and {bond1} set to 'UP' state.\n{out}"
+    # 4.Init interfaces
+    dev_groups = tgen_utils_dev_groups_from_config(
+        [{'ixp': bond1, 'ip': '10.0.0.3', 'gw': '10.0.0.1', 'plen': 24, 'lag_members': [tg_ports[0]]},
+         {'ixp': tg_ports[1], 'ip': '11.0.0.3', 'gw': '11.0.0.1', 'plen': 24}]
+    )
+    await tgen_utils_traffic_generator_connect(tgen_dev, tg_ports, dut_ports, dev_groups)
+
+    # 5.Configure lldp tx-interval 2 sec, bond-slave-src-mac-type real and lldp status rx-and-tx
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'lldp': '', 'tx-interval': lldp_interval}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp tx-interval {lldp_interval}.\n{out}'
+
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'system': 'bond-slave-src-mac-type real'}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp .\n{out}'
+
+    tx_before = await get_lldp_statistic(dev_name, dut_ports[0])
+    out = await Lldp.configure(
+        input_data=[{dev_name: [
+            {'interface': dut_ports[0], 'ports': '', 'lldp': '', 'status': 'rx-and-tx'}]}])
+    assert not out[0][dev_name]['rc'], f'Failed to configure lldp status on port {dut_ports[0]}.\n{out}'
+
+    # 6.Setup lldp packet for trasmitting to first DUT port and start sending
+    chassis = random_mac()
+    port = 'FastEthernet/19'
+    ttl = 110
+    port_subtype = 5
+    lldp = {
+            'chassisLen': (len(chassis.replace(':', '')) // 2) + 1,
+            'chassisSubtype': 4,
+            'chassisVarLen': len(chassis.replace(':', '')) // 2,
+            'chassisId': chassis.replace(':', ''),
+            'portLen': (len(port.encode().hex()) // 2) + 1,
+            'portSubtype': port_subtype,
+            'portVarLen': len(port.encode().hex()) // 2,
+            'portId': port.encode().hex(),
+            'ttlLen': 2,
+            'ttlVal': ttl
+    }
+    lldp_stream = get_lldp_stream(dev_groups[bond1][0]['name'], dev_groups[tg_ports[1]][0]['name'], lldp)
+
+    try:
+        await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=lldp_stream)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
+
+    await tgen_utils_start_traffic(tgen_dev)
+    await asyncio.sleep(lldp_interval * wait)
+
+    # 7.Verify lldp pkt received and mandatory fields are as expected
+    await verify_rx_lldp_fields(dev_name, dut_ports[0], chassis, port, port_subtype, ttl)
+
+    # 8.Verify lldp pkt's were transmitted with all fields as expected
+    tx_after = await get_lldp_statistic(dev_name, dut_ports[0])
+    assert tx_after >= tx_before + wait, f'tx_after {tx_after} >= tx_before {tx_before}'
+    await verify_tx_lldp_fields(dev_name, dent_dev, dut_ports[0], lldp_interval, optional_tlvs=True)


### PR DESCRIPTION
Add Lldp functional tests:

- test_lldp_received[basic]
- test_lldp_received[mandatory]
- test_lldp_received[ttl]
- test_lldp_rx[disable]
- test_lldp_rx[port_down_up]
- test_lldp_transmitted[basic]
- test_lldp_transmitted[mandatory]
- test_lldp_transmitted[optional]
- test_lldp_tx[disabled]
- test_lldp_tx[port_down]
- test_lldp_tx[interval]
- test_lldp_tx_hold
- test_lldp_bridge
- test_lldp_enable_disable_ports
- test_lldp_lag
- test_lldp_max_neighbours

Depends on: #154, #148 


