### PR TITLE
Bugfixes

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_all_selectors.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/acl/test_acl_all_selectors.py
@@ -126,7 +126,7 @@ async def test_acl_all_selectors(testbed, action, use_tagged_traffic, qdisc_type
     use_shared_block = qdisc_type == 'shared_block'
     is_vlan_aware = use_tagged_traffic == 'tagged'
 
-    vlan = random.randint(1, 4095) if is_vlan_aware else 0
+    vlan = random.randint(1, 4094) if is_vlan_aware else 0
     tc_stats_update_time = 5
     traffic_duration = 10
     rate_pps = 10_000

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/test_ecmp.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ecmp/test_ecmp.py
@@ -512,7 +512,14 @@ async def test_ecmp_distribution_lags(testbed):
         'frame_rate_type': 'line_rate',
         }
     }
-    await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+
+    try:
+        await tgen_utils_setup_streams(tgen_dev, config_file_name=None, streams=stream)
+    except AssertionError as e:
+        if 'LAG' in str(e):
+            pytest.skip(str(e))
+        else:
+            raise  # will re-raise the AssertionError
 
     # 9.Transmit added stream for 15 sec
     await tgen_utils_clear_traffic_stats(tgen_dev)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/ipv6/test_ipv6_bridge.py
@@ -169,7 +169,7 @@ async def test_ipv6_on_bridge_vlan(testbed):
     wait_for_stats = 10
     plen = 64
     bridge = 'br0'
-    vlans = random.sample(range(1, 4095), 4)
+    vlans = random.sample(range(1, 4094), 4)
     vlan_ifs = [f'{bridge}.{vlan}' for vlan in vlans]
 
     address_map = [

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_no_traffic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/lacp/test_lacp_no_traffic.py
@@ -1,5 +1,6 @@
 import pytest
 import re
+import asyncio
 
 from dent_os_testbed.lib.ip.ip_link import IpLink
 from dent_os_testbed.utils.test_utils.tgen_utils import tb_get_all_devices
@@ -44,6 +45,7 @@ async def test_lacp_unsupported_modes(testbed):
          'operstate': 'up'} for mode in unsupported_modes]}])
     assert out[0][device]['rc'] == 0, 'Fail to set bond(s) to up state'
 
+    await asyncio.sleep(15)
     # 3. Verify bond(s) with unsupported modes are in `down` state
     for mode in unsupported_modes:
         out = await IpLink.show(input_data=[{device: [{'device': f'bond_{unsupported_modes.index(mode)}',

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_class_precedence.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_class_precedence.py
@@ -93,7 +93,7 @@ async def test_qos_class_precedence(testbed, trust_mode):
         await configure_dscp_map_and_verify(dent, {port: dscp_prio_map for port in ingress_ports})
     else:
         dscp_prio_map = {}
-        vlan = random.randint(2, 4095)
+        vlan = random.randint(2, 4094)
         out = await BridgeVlan.delete(input_data=[{dent: [
             {'device': port, 'vid': 1} for port in ports
         ]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_default_prio.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_default_prio.py
@@ -58,7 +58,7 @@ async def test_qos_default_prio(testbed):
     tg_ports = tgen_dev.links_dict[dent][0][:num_of_ports]
     ports = tgen_dev.links_dict[dent][1][:num_of_ports]
     ingress_port, *egress_ports = ports
-    vlan = random.randint(2, 4095)
+    vlan = random.randint(2, 4094)
     wait_for_qd_stats = 5  # sec
     traffic_duration = 30  # sec
     dscp_not_in_map = 63

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_shaper.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_shaper.py
@@ -96,7 +96,7 @@ async def test_qos_shaper(testbed, trust_mode):
         await configure_dscp_map_and_verify(dent, {ingress_port: dscp_prio_map})
     else:
         dscp_prio_map = {}
-        vlan = random.randint(2, 4095)
+        vlan = random.randint(2, 4094)
         out = await BridgeVlan.delete(input_data=[{dent: [
             {'device': port, 'vid': 1} for port in ports
         ]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_trust_mode.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/qos/test_qos_trust_mode.py
@@ -107,7 +107,7 @@ async def test_qos_trust_mode(testbed, trust_mode, scheduler_type):
         await configure_dscp_map_and_verify(dent, {ports[0]: dscp_prio_map})
     else:
         # 4. Configure vlans on bridge members
-        vlan = random.randint(2, 4095)
+        vlan = random.randint(2, 4094)
         out = await BridgeVlan.delete(input_data=[{dent: [
             {'device': port, 'vid': 1} for port in ports
         ]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/cleanup_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/cleanup_utils.py
@@ -62,7 +62,7 @@ async def cleanup_vrfs(dev):
         parse_output=True
     )
     vrfs_info = out[0][dev.host_name]['parsed_output']
-    if all(vrfs_info):
+    if vrfs_info:
         await IpLink.delete(input_data=[{dev.host_name: [
             {'device': vrf_obj['ifname']} for vrf_obj in vrfs_info
         ]}])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/utils/test_utils/tgen_utils.py
@@ -423,7 +423,7 @@ async def tgen_utils_setup_streams(device, config_file_name, streams, force_upda
     device.applog.info('Starting Protocols')
     out = await TrafficGen.start_protocols(input_data=[{device.host_name: [{}]}])
     device.applog.info(out)
-    assert out[0][device.host_name]['rc'] == 0
+    assert out[0][device.host_name]['rc'] == 0, out[0][device.host_name]['result']
 
 
 async def tgen_utils_start_traffic(device):

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -216,8 +216,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
         Changes media modes for Ixia ports
         """
         for port, vport in vports.items():
-            # or vport[0].L1Config.Ethernet
-            card = vport[0].L1Config.NovusTenGigLan
+            card = vport[0].L1Config.NovusTenGigLan or vport[0].L1Config.Ethernet
             if device.media_mode == 'mixed':
                 # Get required media mode. Default - copper
                 required_media = next((link[2] for link in device.links if link[0] == port), 'copper')

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -128,7 +128,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
 
             # Add ports
             for port, vport in vports.items():
-                if vport[0].href in lag_ports:
+                if vport[0].href in lag_ports or port not in dev_groups.keys():
                     continue
                 device.applog.info('Adding interface on ixia port {} swp {}'.format(port, vport[1]))
                 topo = IxnetworkIxiaClientImpl.ixnet.Topology.add(Vports=vport[0])

--- a/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
+++ b/DentOS_Framework/DentOsTestbedLib/src/dent_os_testbed/lib/traffic/ixnetwork/ixnetwork_ixia_client_impl.py
@@ -94,7 +94,7 @@ class IxnetworkIxiaClientImpl(IxnetworkIxiaClient):
             IxnetworkIxiaClientImpl.stack_template = {
                 stack_type: IxnetworkIxiaClientImpl.ixnet.Traffic.ProtocolTemplate.find(StackTypeId=f'^{stack_type}$')
                 for stack_type in ('ipv4', 'ipv6', 'vlan', 'ethernet', 'tcp', 'udp', 'icmpv1', 'icmpv2', 'icmpv6',
-                                   'igmpv2', 'igmpv3MembershipQuery', 'igmpv3MembershipReport',
+                                   'igmpv2', 'igmpv3MembershipQuery', 'igmpv3MembershipReport', 'llc',
                                    'stpCfgBPDU', 'stpTCNBPDU', 'rstpBPDU')
             }
 


### PR DESCRIPTION
- Add missing LLC protocol stack type 
- Use either Novus card or Ethernet card 
- Add endpoint only if port is included in device_groups 
- Update tgen_utils_setup_streams function 
- Add wait before verification 
- Skip ecmp test if Ixia card does not support LAG 
- Fix cleanup function from getting stuck 
- Update vlan id in tests 

Signed-off-by: Serhiy Boiko <serhiy.boiko@plvision.eu>
Signed-off-by: Stepan Vovk <stepan.vovk@plvision.eu>
Signed-off-by: Andriy Lozovyy <andriy.lozovyy@plvision.eu>