### PR TITLE
Add VRRP tests with traffic

### DIFF
--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/devlink/devlink_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/devlink/devlink_utils.py
@@ -7,7 +7,9 @@ from dent_os_testbed.utils.test_utils.tgen_utils import tgen_utils_get_swp_info
 
 
 CPU_MAX_PPS = 4000
+CPU_MAX_VRRP_PPS = 200
 CPU_STAT_CODE_ACL_CODE_3 = '195'
+CPU_STAT_CODE_VRRP = '30'
 DEVIATION = 0.1
 RATE_UNITS = {
         'bit':  1,

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/conftest.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/conftest.py
@@ -1,14 +1,16 @@
 import pytest_asyncio
+import asyncio
 
 from dent_os_testbed.lib.os.service import Service
 
 
 KEEPALIVE_CONF = '/etc/keepalived/keepalived.conf'
-TEMPLATE = """
-global_defs {{
+HEADER = """
+global_defs {
     vrrp_garp_master_refresh 60
-}}
-
+}
+"""
+TEMPLATE = """
 vrrp_instance vrrp_{vr_id} {{
     state {state}
     interface {dev}
@@ -34,16 +36,23 @@ async def configure_vrrp():
         devs_to_clear.add(dent_dev)
         dent = dent_dev.host_name
         opts = '\n'.join(additional_opts) if type(additional_opts) is list else ''
-        append = '>' if clear else '>>'
+        ips = '\n'.join(vr_ip) if type(vr_ip) is list else vr_ip
+        if clear:
+            rc, _ = await dent_dev.run_cmd(f"""
+                cat << EOF > {KEEPALIVE_CONF}
+                    {HEADER}
+                \nEOF""")
+            assert rc == 0, f'Failed to add VRRP config on DUT {dent}'
 
         rc, _ = await dent_dev.run_cmd(f"""
-            cat << EOF {append} {KEEPALIVE_CONF}
-                {TEMPLATE.format(state=state, dev=dev, prio=prio, vr_ip=vr_ip,
+            cat << EOF >> {KEEPALIVE_CONF}
+                {TEMPLATE.format(state=state, dev=dev, prio=prio, vr_ip=ips,
                                  vr_id=vr_id, additional_opts=opts)}
             \nEOF""")
         assert rc == 0, f'Failed to add VRRP config on DUT {dent}'
 
         if apply:
+            await asyncio.sleep(5)
             out = await Service.restart(input_data=[{
                 dent: [{'name': 'keepalived'}]
             }])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_advert.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_advert.py
@@ -1,0 +1,138 @@
+from operator import itemgetter
+from math import isclose as is_close
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.tc.tc_filter import TcFilter
+from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    setup_topo_for_vrrp,
+)
+
+from dent_os_testbed.utils.test_utils.tc_flower_utils import (
+    tcutil_get_tc_stats_pref_map,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding', 'cleanup_bridges'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.usefixtures('cleanup_qdiscs')
+async def test_vrrp_advert_interval(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_advert_interval
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify VRRP advertisement interval setting
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Capture VRRP advertisement packets from each DUT for X seconds
+    5. Verify X packets are received
+    6. Change advertisement interval to 0.1 second
+    7. Verify 10*X packets are received
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 200
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+    """
+    wait_for_keepalived = 10
+    sleep_time_s = 30
+    vrrp_ip = '192.168.1.2'
+    vr_id = 40
+    pref = 100
+    tolerance = 0.1  # 10%
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge=True)
+    infra, agg, bridge, links = itemgetter('infra', 'agg', 'bridge', 'links')(config)
+    links = [link for link in links if agg in link]
+
+    # 3. Configure VRRP on infra devices
+    advert_int = 1
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id,
+                       dev=bridge, additional_opts=[f'advert_int {advert_int}'])
+        for dent, state, prio
+        in zip(infra, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 4. Capture VRRP advertisement packets from each DUT for X seconds
+    out = await TcQdisc.add(input_data=[{agg.host_name: [
+        {'dev': link[agg], 'direction': 'ingress'}
+        for link in links
+    ]}])
+    assert out[0][agg.host_name]['rc'] == 0, 'Failed to create qdisc'
+
+    out = await TcFilter.add(input_data=[{agg.host_name: [
+        {'dev': link[agg],
+         'action': 'pass',
+         'direction': 'ingress',
+         'protocol': 'ip',
+         'pref': pref,
+         'filtertype': {'skip_sw': '', 'dst_ip': '224.0.0.18'}}
+        for link in links
+    ]}])
+    assert out[0][agg.host_name]['rc'] == 0, 'Failed to add tc filter rules'
+
+    agg.applog.info(f'Capture packets for {sleep_time_s}s')
+    await asyncio.sleep(sleep_time_s)
+
+    # 5. Verify X packets are received
+    stats = await asyncio.gather(*[tcutil_get_tc_stats_pref_map(agg.host_name, link[agg])
+                                   for link in links])
+
+    assert is_close(stats[0][pref]['packets'], sleep_time_s / advert_int, rel_tol=tolerance), \
+        f'Expected {sleep_time_s / advert_int} advertisement packets from {infra[0]}'
+    assert stats[1][pref]['packets'] == 0, \
+        f'Expected 0 advertisement packets from {infra[1]} (backup)'
+
+    # 6. Change advertisement interval to 0.1 second
+    #    Also change roles of infra[0] (now backup) and infra[1] (now master)
+    advert_int = 0.1
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id,
+                       dev=bridge, additional_opts=[f'advert_int {advert_int}'])
+        for dent, state, prio
+        in zip(infra, ['BACKUP', 'MASTER'], [100, 200])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 7. Verify 10*X packets are received
+    old_stats = await asyncio.gather(*[tcutil_get_tc_stats_pref_map(agg.host_name, link[agg])
+                                       for link in links])
+
+    agg.applog.info(f'Capture packets for {sleep_time_s}s')
+    await asyncio.sleep(sleep_time_s)
+
+    new_stats = await asyncio.gather(*[tcutil_get_tc_stats_pref_map(agg.host_name, link[agg])
+                                       for link in links])
+
+    pkts = [_new[pref]['packets'] - _old[pref]['packets'] for _new, _old in zip(new_stats, old_stats)]
+
+    assert pkts[0] == 0, \
+        f'Expected 0 advertisement packets from {infra[0]} (backup)'
+    assert is_close(pkts[1], sleep_time_s / advert_int, rel_tol=tolerance), \
+        f'Expected {sleep_time_s / advert_int} advertisement packets from {infra[1]}'

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_advert.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_advert.py
@@ -8,10 +8,22 @@ from dent_os_testbed.lib.tc.tc_qdisc import TcQdisc
 
 from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
     setup_topo_for_vrrp,
+    vr_id_to_mac,
 )
 
 from dent_os_testbed.utils.test_utils.tc_flower_utils import (
     tcutil_get_tc_stats_pref_map,
+)
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+)
+
+from dent_os_testbed.test.test_suite.functional.devlink.devlink_utils import (
+    verify_cpu_traps_rate_code_avg,
+    CPU_STAT_CODE_VRRP,
+    CPU_MAX_VRRP_PPS,
 )
 
 
@@ -58,7 +70,7 @@ async def test_vrrp_advert_interval(testbed, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     sleep_time_s = 30
     vrrp_ip = '192.168.1.2'
     vr_id = 40
@@ -136,3 +148,96 @@ async def test_vrrp_advert_interval(testbed, configure_vrrp):
         f'Expected 0 advertisement packets from {infra[0]} (backup)'
     assert is_close(pkts[1], sleep_time_s / advert_int, rel_tol=tolerance), \
         f'Expected {sleep_time_s / advert_int} advertisement packets from {infra[1]}'
+
+
+@pytest.mark.usefixtures('cleanup_tgen', 'define_bash_utils')
+async def test_vrrp_advert_overflow(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_advert_overflow
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify DUT stability and availability under VRRP advertisements overflow
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Send VRRPv3 advertisements for 60 seconds
+    5. Verify both infra devices trap those advertisements and they remain stable
+
+    Setup:
+                   TG L0     ______
+            agg ------------ |    |
+         ___| |___           |    |
+      L0 |       | L1        | TG |
+         |       |           |    |
+    infra[0]    infra[1]     |____|
+
+    Configure:
+        agg:
+            L0, L1, TG L0: master bridge
+        infra[0]:
+            L0: master bridge
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 250
+        infra[1]:
+            L1: master bridge
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+        TG:
+            L0: ip address 192.168.1.5/24
+                vrrp 40 ip 192.168.1.2 prio 200
+    """
+    """
+    [no ethernet header]
+    Protocol: VRRP
+    Source Address: 192.168.1.5
+    Destination Address: 224.0.0.18
+    Virtual Router ID: 40
+    Priority: 250
+    VRRP IP Address: 192.168.1.2
+    """
+    vrrp_packet = '45C0002000010000FF7018EDC0A80105E00000123128FA010064708AC0A80102'
+    vrrp_ip = '192.168.1.2'
+    vr_id = 40
+    sleep_time_s = 60
+    wait_for_keepalived = 15
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge=True, use_tgen=True, vrrp_ip=vrrp_ip)
+    infra, tgen_dev, bridge, links, tg_links, dev_groups, ep_ip = \
+        itemgetter('infra', 'tgen_dev', 'bridge', 'links', 'tg_links', 'dev_groups', 'ep_ip')(config)
+
+    # 3. Configure VRRP on infra devices
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=bridge)
+        for dent, state, prio
+        in zip(infra, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 4. Send VRRPv3 advertisements for 60 seconds
+    streams = {
+        'vrrp adv traffic': {
+            'type': 'custom',
+            'protocol': '0800',
+            'ip_source': dev_groups[tg_links[0][tgen_dev]][0]['name'],
+            'ip_destination': dev_groups[tg_links[0][tgen_dev]][0]['name'],
+            'allowSelfDestined': True,
+            'srcMac': vr_id_to_mac(vr_id),
+            'dstMac': '01:00:5e:00:00:12',
+            'frame_rate_type': 'line_rate',
+            'rate': 100,  # %
+            'frameSize': 100,
+            'customLength': len(vrrp_packet) // 2,
+            'customData': vrrp_packet,
+        }
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    # don't stop
+    await asyncio.sleep(sleep_time_s)
+
+    # 5. Verify both infra devices trap those advertisements and they remain stable
+    await asyncio.gather(*[verify_cpu_traps_rate_code_avg(dent, CPU_STAT_CODE_VRRP, CPU_MAX_VRRP_PPS)
+                           for dent in infra])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
@@ -55,7 +55,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     count = 10
     vrrp_ip = '192.168.1.2'
     vr_id = 40
@@ -142,7 +142,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     count = 10
     vrrp_ip = '192.168.1.2'
     vr_id = 40

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
@@ -55,6 +55,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100
     """
+    wait_for_keepalived = 10
     count = 10
     vrrp_ip = '192.168.1.2'
     vr_id = 40
@@ -71,7 +72,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
         configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
         for dent, port, state, prio
         in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [254, 100])])
-    await asyncio.sleep(10)  # wait for keepalived to start
+    await asyncio.sleep(wait_for_keepalived)
 
     # 4. Verify infra[0] serves as master because it has a higher priority,
     #    Verify infra[1] serves as backup
@@ -84,7 +85,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
     }])
     assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
         'Failed to disable vrrp'
-    await asyncio.sleep(10)  # wait for vrrp to change master
+    await asyncio.sleep(wait_for_keepalived)
 
     # 6. Verify infra[1] takes over as master
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
@@ -96,7 +97,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
     }])
     assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
         'Failed to enable vrrp'
-    await asyncio.sleep(10)  # wait for vrrp to change master
+    await asyncio.sleep(wait_for_keepalived)
 
     # 8. Expect that it takes over as the master and infra[1] reverts to backup
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
@@ -141,6 +142,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100
     """
+    wait_for_keepalived = 10
     count = 10
     vrrp_ip = '192.168.1.2'
     vr_id = 40
@@ -157,7 +159,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
         configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
         for dent, port, state, prio
         in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [200, 100])])
-    await asyncio.sleep(10)  # wait for keepalived to start
+    await asyncio.sleep(wait_for_keepalived)
 
     # 4. Verify infra[0] serves as master because it has a higher priority,
     #    Verify infra[1] serves as backup
@@ -170,7 +172,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
     }])
     assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
         'Failed to disable vrrp'
-    await asyncio.sleep(10)  # wait for vrrp to change master
+    await asyncio.sleep(wait_for_keepalived)
 
     # 6. Verify infra[1] takes over as master
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
@@ -182,7 +184,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
     }])
     assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
         'Failed to disable vrrp'
-    await asyncio.sleep(10)  # wait for vrrp to change master
+    await asyncio.sleep(wait_for_keepalived)
 
     # 8. Expect no ICMP reply
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_basic.py
@@ -76,7 +76,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
     # 4. Verify infra[0] serves as master because it has a higher priority,
     #    Verify infra[1] serves as backup
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+                           expected=(count, 0), dst=vrrp_ip, count=count)
 
     # 5. Make infra[0] unavailable
     out = await IpLink.set(input_data=[{
@@ -88,7 +88,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
 
     # 6. Verify infra[1] takes over as master
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(0, count*2), dst=vrrp_ip, count=count)
+                           expected=(0, count), dst=vrrp_ip, count=count)
 
     # 7. Make infra[0] active again
     out = await IpLink.set(input_data=[{
@@ -100,7 +100,7 @@ async def test_vrrp_basic_on(testbed, setup, configure_vrrp):
 
     # 8. Expect that it takes over as the master and infra[1] reverts to backup
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+                           expected=(count, 0), dst=vrrp_ip, count=count)
 
 
 @pytest.mark.parametrize('setup', ['port', 'bridge'])
@@ -162,7 +162,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
     # 4. Verify infra[0] serves as master because it has a higher priority,
     #    Verify infra[1] serves as backup
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+                           expected=(count, 0), dst=vrrp_ip, count=count)
 
     # 5. Make infra[0] unavailable
     out = await IpLink.set(input_data=[{
@@ -174,7 +174,7 @@ async def test_vrrp_basic_down_on(testbed, setup, configure_vrrp):
 
     # 6. Verify infra[1] takes over as master
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(0, count*2), dst=vrrp_ip, count=count)
+                           expected=(0, count), dst=vrrp_ip, count=count)
 
     # 7. Make infra[1] also unavailable
     out = await IpLink.set(input_data=[{

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_interact.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_interact.py
@@ -1,0 +1,179 @@
+import asyncio
+import pytest
+
+from dent_os_testbed.Device import DeviceType
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.mstpctl.mstpctl import Mstpctl
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_get_dent_devices_with_tgen,
+)
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    verify_vrrp_ping,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding', 'cleanup_bridges'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.usefixtures('enable_mstpd')
+async def test_vrrp_and_stp(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_and_stp
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify VRRP functionality and STP work together without interfere each other
+    Test Procedure:
+    1. Configure bridges
+    2. Enslave ports
+    3. Enable stp on infra[0]
+    4. Configure VRRP on infra devices
+    5. Verify bridge on infra[0] has a blocking port
+    6. If infra[0] is available:
+       Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    7. If infra[0] is unavailable:
+       Verify infra[1] takes over as master
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]----infra[1]
+             L2
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.1.5/24
+        infra[0]:
+            L0 and L2: master bridge stp_state 1
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 200
+        infra[1]:
+            L1 and L2: master bridge
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+    """
+    tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [
+        DeviceType.AGGREGATION_ROUTER,
+        DeviceType.INFRA_SWITCH,
+    ], 0)
+    if not tgen_dev or not dent_devices or len(dent_devices) < 3:
+        pytest.skip('The testbed does not have enough devices (1 agg + 2 infra)')
+
+    infra = [dent for dent in dent_devices if dent.type == DeviceType.INFRA_SWITCH]
+    if len(infra) < 2:
+        pytest.skip('The testbed does not have enough infra devices')
+    infra = infra[:2]
+
+    agg = [dent for dent in dent_devices if dent.type == DeviceType.AGGREGATION_ROUTER]
+    if len(agg) < 1:
+        pytest.skip('The testbed does not have enough agg devices')
+    agg = agg[0]
+
+    wait_for_keepalived = 10
+    convergence_time_s = 40
+    vrrp_ip = '192.168.1.2'
+    bridge = 'br0'
+    count = 10
+    vr_id = 40
+    dut_bridge_ip = {
+        infra[0]: '192.168.1.3/24',
+        infra[1]: '192.168.1.4/24',
+        agg: '192.168.1.5/24',
+    }
+    links = [
+        # L0
+        {infra[0]: infra[0].links_dict[agg.host_name][0][0],
+         agg: infra[0].links_dict[agg.host_name][1][0]},
+        # L1
+        {infra[1]: infra[1].links_dict[agg.host_name][0][0],
+         agg: infra[1].links_dict[agg.host_name][1][0]},
+        # L2
+        {infra[0]: infra[0].links_dict[infra[1].host_name][0][0],
+         infra[1]: infra[0].links_dict[infra[1].host_name][1][0]},
+    ]
+
+    # 1. Configure bridges
+    out = await IpLink.add(input_data=[{
+        infra[0].host_name: [{'name': bridge, 'type': 'bridge', 'stp_state': 1}],
+        infra[1].host_name: [{'name': bridge, 'type': 'bridge'}],
+        agg.host_name: [{'name': bridge, 'type': 'bridge'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to add bridges'
+
+    # 2. Enslave ports
+    out = await IpLink.set(input_data=[
+        {
+            dent.host_name: [{'device': port, 'master': bridge, 'operstate': 'up'}]
+            for dent, port in link.items()
+        }
+        for link in links
+    ] + [
+        {
+            dent.host_name: [{'device': bridge, 'operstate': 'up'}]
+        }
+        for dent in infra + [agg]
+    ])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to enslave ports'
+
+    # 3. Enable stp on infra[0]
+    out = await Mstpctl.add(input_data=[{infra[0].host_name: [{'bridge': bridge}]}])
+    assert out[0][infra[0].host_name]['rc'] == 0, 'Failed to add bridge'
+
+    out = await Mstpctl.set(input_data=[{infra[0].host_name: [
+        {'parameter': 'forcevers', 'bridge': bridge, 'version': 'stp'},
+    ]}])
+    assert out[0][infra[0].host_name]['rc'] == 0, 'Failed to enable stp'
+
+    # 4. Configure VRRP on infra devices
+    out = await IpAddress.add(input_data=[{
+        dent.host_name: [{'dev': bridge, 'prefix': prefix}]
+        for dent, prefix in dut_bridge_ip.items()
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to add IP addr'
+
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=bridge)
+        for dent, state, prio
+        in zip(infra, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 5. Verify bridge on infra[0] has a blocking port
+    await asyncio.sleep(convergence_time_s)
+    out = await Mstpctl.show(input_data=[{infra[0].host_name: [
+        {'parameter': 'portdetail', 'bridge': bridge, 'options': '-f json'}
+    ]}], parse_output=True)
+    assert out[0][infra[0].host_name]['rc'] == 0, 'Failed to get port detail'
+
+    assert any(port['state'] == 'discarding' for port in out[0][infra[0].host_name]['parsed_output']), \
+        'Expected one of the ports to be \'discarding\''
+
+    # 6. If infra[0] is available:
+    #    Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    # 7. If infra[0] is unavailable:
+    #    Verify infra[1] takes over as master
+    for state, expected in [('up', [count, 0]),
+                            ('down', [0, count]),
+                            ('up', [count, 0])]:
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': state}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to enable/disable vrrp'
+        await asyncio.sleep(wait_for_keepalived)
+
+        await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                               expected=expected, dst=vrrp_ip, count=count)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_preempt.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_preempt.py
@@ -51,7 +51,7 @@ async def test_vrrp_preempt_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100 (prio 210 nopreempt)
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     count = 10
     vrrp_ip = '192.168.1.2'
     vr_id = 40

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_preempt.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_preempt.py
@@ -16,20 +16,20 @@ pytestmark = [
 
 
 @pytest.mark.parametrize('setup', ['port', 'bridge'])
-async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
+async def test_vrrp_preempt_on(testbed, setup, configure_vrrp):
     """
-    Test Name: test_vrrp_priority_on[port|bridge]
+    Test Name: test_vrrp_basic_on[port|bridge]
     Test Suite: suite_functional_vrrp
     Test Overview:
-        Verify that the VR configured over a port with the highest priority becomes the master.
+        Verify basic VRRP configuration
     Test Procedure:
     1. Configure aggregation router
     2. Configure infra devices
     3. Configure VRRP on infra devices
     4. Verify infra[0] serves as master because it has a higher priority,
        Verify infra[1] serves as backup
-    5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
-    6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
+    5. Change VRRP configuration on infra[1] to have a higher priority and 'nopreempt' flag
+    6. Verify infra[0] is still master
 
     Setup:
             agg
@@ -49,11 +49,12 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
         infra[1]:
             L1 (port/bridge):
                 ip address 192.168.1.4/24
-                vrrp 40 ip 192.168.1.2 prio 100(210)
+                vrrp 40 ip 192.168.1.2 prio 100 (prio 210 nopreempt)
     """
     wait_for_keepalived = 10
     count = 10
     vrrp_ip = '192.168.1.2'
+    vr_id = 40
     use_bridge = setup == 'bridge'
 
     # 1. Configure aggregation router
@@ -64,7 +65,7 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
     # 3. Configure VRRP on infra devices
     vrrp_ifaces = [bridge, bridge] if use_bridge else [links[0][infra[0]], links[1][infra[1]]]
     await asyncio.gather(*[
-        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, dev=port)
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
         for dent, port, state, prio
         in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [200, 100])])
     await asyncio.sleep(wait_for_keepalived)
@@ -74,11 +75,11 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
                            expected=(count, 0), dst=vrrp_ip, count=count)
 
-    # 5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
-    await configure_vrrp(infra[1], state='MASTER', prio=210, vr_ip=vrrp_ip,
-                         dev=links[1][infra[1]] if setup == 'port' else bridge)
-    await asyncio.sleep(10)  # wait for keepalived to restart
+    # 5. Change VRRP configuration on infra[1] to have a higher priority and 'nopreempt' flag
+    await configure_vrrp(infra[1], state='BACKUP', prio=210, vr_ip=vrrp_ip, vr_id=vr_id,
+                         dev=links[1][infra[1]], additional_opts=['nopreempt'])
+    await asyncio.sleep(wait_for_keepalived)
 
-    # 6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
+    # 6. Verify infra[0] is still MASTER
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(0, count), dst=vrrp_ip, count=count)
+                           expected=(count, 0), dst=vrrp_ip, count=count)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
@@ -71,7 +71,7 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
     # 4. Verify infra[0] serves as master because it has a higher priority,
     #    Verify infra[1] serves as backup
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(count*2, 0), dst=vrrp_ip, count=count)
+                           expected=(count, 0), dst=vrrp_ip, count=count)
 
     # 5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
     await configure_vrrp(infra[1], state='MASTER', prio=210, vr_ip=vrrp_ip,
@@ -80,4 +80,4 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
 
     # 6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
-                           expected=(0, count*2), dst=vrrp_ip, count=count)
+                           expected=(0, count), dst=vrrp_ip, count=count)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_priority.py
@@ -51,7 +51,7 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
                 ip address 192.168.1.4/24
                 vrrp 40 ip 192.168.1.2 prio 100(210)
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     count = 10
     vrrp_ip = '192.168.1.2'
     use_bridge = setup == 'bridge'
@@ -77,7 +77,7 @@ async def test_vrrp_priority_on(testbed, setup, configure_vrrp):
     # 5. Set infra[1] VRRP priority greater than the infra[0] VRRP priority
     await configure_vrrp(infra[1], state='MASTER', prio=210, vr_ip=vrrp_ip,
                          dev=links[1][infra[1]] if setup == 'port' else bridge)
-    await asyncio.sleep(10)  # wait for keepalived to restart
+    await asyncio.sleep(wait_for_keepalived)  # wait for keepalived to restart
 
     # 6. Verify infra[1] takes over as a master and infra[0] becomes a backup router
     await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_under_traffic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_under_traffic.py
@@ -1,0 +1,142 @@
+from operator import itemgetter
+import asyncio
+import pytest
+import random
+import math
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+    tgen_utils_poll,
+)
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    setup_topo_for_vrrp,
+    get_rx_bps,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding',
+                            'cleanup_bridges', 'cleanup_tgen'),
+    pytest.mark.asyncio,
+]
+
+
+@pytest.mark.parametrize('setup', ['bridge', 'vlan', 'port'])
+async def test_vrrp_under_traffic(testbed, setup, configure_vrrp):
+    """
+    Test Name: test_vrrp_under_traffic
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify basic VRRP configuration when a macvlan is created over a bridge and under heavy traffic
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+
+    Setup:
+                   TG L0     ______
+            agg ------------ |    |
+         ___| |___           |    |
+      L0 |       | L1        | TG |
+         |       |           |    |
+    infra[0] -- infra[1] --- |____|
+             L2         TG L1
+
+    Configure:
+        agg:
+            L0, L1, TG L0: master bridge
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.1.2 prio 200
+            L2:
+                ip address 192.168.3.10/24
+                route 192.168.2.2 via 192.168.3.11
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.1.4/24
+                vrrp 40 ip 192.168.1.2 prio 100
+            TG L1:
+                ip address 192.168.2.1/24
+            L2:
+                ip address 192.168.3.11/24
+        TG:
+            L0: ip address 192.168.1.5/24
+            L1: ip address 192.168.2.2/24
+    """
+    wait_for_keepalived = 10
+    vrrp_ip = '192.168.1.2'
+    vr_id = 40
+    packet_size = random.randint(100, 1500)
+    max_rate_bit = 1_000_000_000  # 1Gbit, 100%
+    rate_bit = max_rate_bit * 0.85  # ~850Mbit, 85%
+    rate_bps = rate_bit // 8  # ~100Mbps, 85%
+
+    if setup == 'bridge':
+        use_bridge = True
+        vlan = None
+    elif setup == 'vlan':
+        use_bridge = True
+        vlan = random.randint(2, 4094) if setup == 'vlan' else None
+    else:
+        use_bridge = False
+        vlan = None
+
+    # 1. Configure aggregation router
+    config = await setup_topo_for_vrrp(testbed, use_bridge, use_vid=vlan, use_tgen=True, vrrp_ip=vrrp_ip)
+    infra, tgen_dev, bridge, links, tg_links, dev_groups, vlan_dev = \
+        itemgetter('infra', 'tgen_dev', 'bridge', 'links', 'tg_links', 'dev_groups', 'vlan_dev')(config)
+
+    if setup == 'bridge':
+        vrrp_ifaces = [bridge, bridge]
+    elif setup == 'vlan':
+        vrrp_ifaces = [vlan_dev, vlan_dev]
+    else:
+        vrrp_ifaces = [links[0][infra[0]], links[1][infra[1]]]
+
+    # 3. Configure VRRP on infra devices
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ip, vr_id=vr_id, dev=port)
+        for dent, port, state, prio
+        in zip(infra, vrrp_ifaces, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    streams = {
+        'data traffic': {
+            'type': 'ipv4',
+            'ip_source': dev_groups[tg_links[0][tgen_dev]][0]['name'],  # TG L0
+            'ip_destination': dev_groups[tg_links[1][tgen_dev]][0]['name'],  # TG L1
+            'frameSize': packet_size,
+            'frame_rate_type': 'bps_rate',
+            'rate': rate_bit,
+        },
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    # don't stop
+
+    for state, expected in [('up', [rate_bps, 0]),
+                            ('down', [0, rate_bps]),
+                            ('up', [rate_bps, 0])]:
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': state}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to enable/disable vrrp'
+        await asyncio.sleep(wait_for_keepalived)
+
+        async def verify_correct_traffic(dent, port, expected_rate):
+            current_rate = await get_rx_bps(dent, port)
+            assert math.isclose(current_rate, expected_rate, rel_tol=0.10, abs_tol=1000), \
+                f'Expected rate for {dent}: {expected_rate}, actual: {current_rate}'
+
+        await asyncio.gather(*[tgen_utils_poll(infra[idx], verify_correct_traffic,
+                                               dent=infra[idx].host_name, port=links[idx][infra[idx]],
+                                               expected_rate=expected[idx], timeout=90)
+                               for idx in [0, 1]])

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_under_traffic.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_under_traffic.py
@@ -69,7 +69,7 @@ async def test_vrrp_under_traffic(testbed, setup, configure_vrrp):
             L0: ip address 192.168.1.5/24
             L1: ip address 192.168.2.2/24
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     vrrp_ip = '192.168.1.2'
     vr_id = 40
     packet_size = random.randint(100, 1500)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_vrouter.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_vrouter.py
@@ -62,7 +62,7 @@ async def test_vrrp_master_and_backup(testbed, configure_vrrp):
                 vrrp 40 ip 192.168.10.2 prio 100 (BACKUP)
                 vrrp 50 ip 192.168.20.2 prio 200 (MASTER)
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     vr_addr = ['192.168.10.2', '192.168.20.2']
     count = 10
 
@@ -146,7 +146,7 @@ async def test_vrrp_multiple_addr(testbed, configure_vrrp):
                 ...
                 vrrp 40 ip 192.168.20.255 prio 100
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     vrrp_ips = [f'192.168.20.{ip+1}' for ip in range(255)]
     count = len(vrrp_ips)
     vr_id = 40
@@ -249,7 +249,7 @@ async def test_vrrp_max_instances(testbed, configure_vrrp):
                 ...
                 vrrp 254 ip 192.168.20.254 prio 100
     """
-    wait_for_keepalived = 10
+    wait_for_keepalived = 15
     vr_ids = [id+1 for id in range(254)]
     vrrp_ips = [f'192.168.20.{id}' for id in vr_ids]
     count = len(vrrp_ips)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_vrouter.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/test_vrrp_vrouter.py
@@ -1,0 +1,314 @@
+from operator import itemgetter
+import asyncio
+import pytest
+
+from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_address import IpAddress
+
+from dent_os_testbed.utils.test_utils.tgen_utils import (
+    tgen_utils_setup_streams,
+    tgen_utils_start_traffic,
+)
+
+from dent_os_testbed.test.test_suite.functional.vrrp.vrrp_utils import (
+    setup_topo_for_vrrp,
+    verify_vrrp_ping,
+    vr_id_to_mac,
+)
+
+
+pytestmark = [
+    pytest.mark.suite_functional_vrrp,
+    pytest.mark.usefixtures('cleanup_ip_addrs', 'enable_ipv4_forwarding', 'cleanup_bridges'),
+    pytest.mark.asyncio,
+]
+
+
+async def test_vrrp_master_and_backup(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_master_and_backup
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify DUT can be both MASTER for one VRID and at the same time BACKUP for another
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Verify infra[0] serves as master, infra[1] serves as backup (vr id 40)
+    5. Verify infra[1] serves as master, infra[0] serves as backup (vr id 50)
+
+    Setup:
+            agg
+         ___| |___
+      L0 |       | L1
+         |       |
+    infra[0]    infra[1]
+
+    Configure:
+        agg:
+            L0 and L1: master bridge
+            bridge: ip address 192.168.10.5/24
+                               192.168.20.5/24
+        infra[0]:
+            L0 (port/bridge):
+                ip address 192.168.10.3/24
+                           192.168.20.3/24
+                vrrp 40 ip 192.168.10.2 prio 200 (MASTER)
+                vrrp 50 ip 192.168.20.2 prio 100 (BACKUP)
+        infra[1]:
+            L1 (port/bridge):
+                ip address 192.168.10.4/24
+                           192.168.20.4/24
+                vrrp 40 ip 192.168.10.2 prio 100 (BACKUP)
+                vrrp 50 ip 192.168.20.2 prio 200 (MASTER)
+    """
+    wait_for_keepalived = 10
+    vr_addr = ['192.168.10.2', '192.168.20.2']
+    count = 10
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge=True)
+    infra, agg, bridge, links = itemgetter('infra', 'agg', 'bridge', 'links')(config)
+
+    out = await IpAddress.add(input_data=[{
+        agg.host_name: [{'dev': bridge, 'prefix': '192.168.10.5/24'},
+                        {'dev': bridge, 'prefix': '192.168.20.5/24'}],
+        infra[0].host_name: [{'dev': bridge, 'prefix': '192.168.10.3/24'},
+                             {'dev': bridge, 'prefix': '192.168.20.3/24'}],
+        infra[1].host_name: [{'dev': bridge, 'prefix': '192.168.10.4/24'},
+                             {'dev': bridge, 'prefix': '192.168.20.4/24'}],
+    }])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to add IP addr'
+
+    # 3. Configure VRRP on infra devices
+    await asyncio.gather(*[
+        configure_vrrp(infra[0], state='MASTER', prio=200, vr_ip=vr_addr[0], vr_id=40, dev=bridge, apply=False),
+        configure_vrrp(infra[1], state='BACKUP', prio=100, vr_ip=vr_addr[0], vr_id=40, dev=bridge, apply=False),
+    ])
+    await asyncio.gather(*[
+        configure_vrrp(infra[0], state='BACKUP', prio=100, vr_ip=vr_addr[1],
+                       vr_id=50, dev=bridge, apply=True, clear=False),
+        configure_vrrp(infra[1], state='MASTER', prio=200, vr_ip=vr_addr[1],
+                       vr_id=50, dev=bridge, apply=True, clear=False),
+    ])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 4. Verify infra[0] serves as master, infra[1] serves as backup (vr id 40)
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(count, 0), dst=vr_addr[0], count=count)
+
+    # 5. Verify infra[1] serves as master, infra[0] serves as backup (vr id 50)
+    await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                           expected=(0, count), dst=vr_addr[1], count=count)
+
+
+@pytest.mark.usefixtures('cleanup_tgen')
+async def test_vrrp_multiple_addr(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_multiple_addr
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify it possible to set multiple IP addresses on a single virtual router and their availability
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Setup ICMP echo request stream
+    5. If infra[0] is available:
+       Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    6. If infra[0] is unavailable:
+       Verify infra[1] takes over as master
+
+    Setup:
+                   TG L0     ______
+            agg ------------ |    |
+         ___| |___           |    |
+      L0 |       | L1        | TG |
+         |       |           |    |
+    infra[0]    infra[1]     |____|
+
+    Configure:
+        agg:
+            L0, L1, TG L0: master bridge
+        infra[0]:
+            L0: master bridge
+                ip address 192.168.1.2/24
+                vrrp 40 ip 192.168.20.1 prio 200
+                ...
+                vrrp 40 ip 192.168.20.255 prio 200
+        infra[1]:
+            L1: master bridge
+                ip address 192.168.1.3/24
+                vrrp 40 ip 192.168.20.1 prio 100
+                ...
+                vrrp 40 ip 192.168.20.255 prio 100
+    """
+    wait_for_keepalived = 10
+    vrrp_ips = [f'192.168.20.{ip+1}' for ip in range(255)]
+    count = len(vrrp_ips)
+    vr_id = 40
+    rate_pps = 50
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge=True, use_tgen=True, vrrp_ip=vrrp_ips[0])
+    infra, agg, tgen_dev, bridge, links, tg_links, dev_groups = \
+        itemgetter('infra', 'agg', 'tgen_dev', 'bridge', 'links', 'tg_links', 'dev_groups')(config)
+
+    # 3. Configure VRRP on infra devices
+    await asyncio.gather(*[
+        configure_vrrp(dent, state=state, prio=prio, vr_ip=vrrp_ips, vr_id=vr_id, dev=bridge)
+        for dent, state, prio
+        in zip(infra, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 4. Setup ICMP echo request stream
+    streams = {
+        'icmp': {
+            'type': 'raw',
+            'protocol': 'ip',
+            'frameSize': 100,
+            'ip_source': dev_groups[tg_links[0][tgen_dev]][0]['name'],
+            'ip_destination': dev_groups[tg_links[1][tgen_dev]][0]['name'],
+            'srcMac': '02:00:00:00:00:01',
+            'dstMac': vr_id_to_mac(vr_id),
+            'srcIp': dev_groups[tg_links[0][tgen_dev]][0]['ip'],
+            'dstIp': {'type': 'list', 'list': vrrp_ips},
+            'ipproto': 'icmpv2',
+            'icmpType': '8',
+            'icmpCode': '0',
+            'rate': rate_pps,
+        },
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    # don't stop
+
+    # 5. If infra[0] is available:
+    #    Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    # 6. If infra[0] is unavailable:
+    #    Verify infra[1] takes over as master
+    for state, expected in [('up', (count, 0)),
+                            ('down', (0, count)),
+                            ('up', (count, 0))]:
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [{'device': f'vrrp.{vr_id}', 'operstate': state}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to disable vrrp'
+        await asyncio.sleep(wait_for_keepalived)
+
+        await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                               expected=expected, count=count, do_ping=False, interval=1/rate_pps)
+
+
+@pytest.mark.usefixtures('cleanup_tgen')
+async def test_vrrp_max_instances(testbed, configure_vrrp):
+    """
+    Test Name: test_vrrp_max_instances
+    Test Suite: suite_functional_vrrp
+    Test Overview:
+        Verify it is possible to configure maximum number of VRRP interfaces and verify their connectivity
+    Test Procedure:
+    1. Configure aggregation router
+    2. Configure infra devices
+    3. Configure VRRP on infra devices
+    4. Setup ICMP echo request stream
+    5. If infra[0] is available:
+       Verify infra[0] serves as master because it has a higher priority,
+       Verify infra[1] serves as backup
+    6. If infra[0] is unavailable:
+       Verify infra[1] takes over as master
+
+    Setup:
+                   TG L0     ______
+            agg ------------ |    |
+         ___| |___           |    |
+      L0 |       | L1        | TG |
+         |       |           |    |
+    infra[0]    infra[1]     |____|
+
+    Configure:
+        agg:
+            L0, L1, TG L0: master bridge
+        infra[0]:
+            L0: master bridge
+                ip address 192.168.1.2/24
+                vrrp 1 ip 192.168.20.1 prio 200
+                ...
+                vrrp 254 ip 192.168.20.254 prio 200
+        infra[1]:
+            L1: master bridge
+                ip address 192.168.1.3/24
+                vrrp 1 ip 192.168.20.1 prio 100
+                ...
+                vrrp 254 ip 192.168.20.254 prio 100
+    """
+    wait_for_keepalived = 10
+    vr_ids = [id+1 for id in range(254)]
+    vrrp_ips = [f'192.168.20.{id}' for id in vr_ids]
+    count = len(vrrp_ips)
+    rate_pps = 50
+
+    # 1. Configure aggregation router
+    # 2. Configure infra devices
+    config = await setup_topo_for_vrrp(testbed, use_bridge=True, use_tgen=True, vrrp_ip=vrrp_ips[0])
+    infra, agg, tgen_dev, bridge, links, tg_links, dev_groups = \
+        itemgetter('infra', 'agg', 'tgen_dev', 'bridge', 'links', 'tg_links', 'dev_groups')(config)
+
+    # 3. Configure VRRP on infra devices
+    for id, ip in zip(vr_ids, vrrp_ips):
+        await asyncio.gather(*[
+            configure_vrrp(dent, state=state, prio=prio, vr_ip=ip, vr_id=id, dev=bridge,
+                           clear=ip == vrrp_ips[0], apply=ip == vrrp_ips[-1],
+                           additional_opts=['advert_int 3'])
+            for dent, state, prio
+            in zip(infra, ['MASTER', 'BACKUP'], [200, 100])])
+    await asyncio.sleep(wait_for_keepalived)
+
+    # 4. Setup ICMP echo request stream
+    streams = {
+        'icmp': {
+            'type': 'raw',
+            'protocol': 'ip',
+            'frameSize': 100,
+            'ip_source': dev_groups[tg_links[0][tgen_dev]][0]['name'],
+            'ip_destination': dev_groups[tg_links[1][tgen_dev]][0]['name'],
+            'srcMac': '02:00:00:00:00:01',
+            'dstMac': {'type': 'list', 'list': [vr_id_to_mac(id) for id in vr_ids]},
+            'srcIp': dev_groups[tg_links[0][tgen_dev]][0]['ip'],
+            'dstIp': {'type': 'list', 'list': vrrp_ips},
+            'ipproto': 'icmpv2',
+            'icmpType': '8',
+            'icmpCode': '0',
+            'rate': rate_pps,
+        },
+    }
+    await tgen_utils_setup_streams(tgen_dev, None, streams)
+
+    await tgen_utils_start_traffic(tgen_dev)
+    # don't stop
+
+    # 5. If infra[0] is available:
+    #    Verify infra[0] serves as master because it has a higher priority,
+    #    Verify infra[1] serves as backup
+    # 6. If infra[0] is unavailable:
+    #    Verify infra[1] takes over as master
+    for state, expected in [('up', (count, 0)),
+                            ('down', (0, count)),
+                            ('up', (count, 0))]:
+        out = await IpLink.set(input_data=[{
+            infra[0].host_name: [{'device': f'vrrp.{id}', 'operstate': state}
+                                 for id in vr_ids],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to disable vrrp'
+        await asyncio.sleep(20)  # wait for vrrp to change master
+
+        await verify_vrrp_ping(agg, infra, ports=(links[0][infra[0]], links[1][infra[1]]),
+                               expected=expected, count=count, do_ping=False, interval=1/rate_pps)

--- a/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/vrrp_utils.py
+++ b/DentOS_Framework/DentOsTestbed/src/dent_os_testbed/test/test_suite/functional/vrrp/vrrp_utils.py
@@ -3,10 +3,16 @@ import pytest
 
 from dent_os_testbed.Device import DeviceType
 from dent_os_testbed.lib.ip.ip_link import IpLink
+from dent_os_testbed.lib.ip.ip_route import IpRoute
 from dent_os_testbed.lib.ip.ip_address import IpAddress
+from dent_os_testbed.lib.ethtool.ethtool import Ethtool
+from dent_os_testbed.lib.ip.ip_neighbor import IpNeighbor
+from dent_os_testbed.lib.bridge.bridge_vlan import BridgeVlan
 
 from dent_os_testbed.utils.test_utils.tgen_utils import (
     tgen_utils_get_dent_devices_with_tgen,
+    tgen_utils_traffic_generator_connect,
+    tgen_utils_dev_groups_from_config,
 )
 
 from dent_os_testbed.utils.test_utils.tb_utils import (
@@ -15,23 +21,36 @@ from dent_os_testbed.utils.test_utils.tb_utils import (
 )
 
 
-async def setup_topo_for_vrrp(testbed, use_bridge=False):
+def vr_id_to_mac(vr):
+    return f'00:00:5e:00:01:{vr:02x}'
+
+
+async def setup_topo_for_vrrp(testbed, use_bridge=False, use_vid=None, use_tgen=False, vrrp_ip=None):
     """
     Setup:
-            agg
-         ___| |___
-      L0 |       | L1
-         |       |
-    infra[0]    infra[1]
+                   TG L0     ______
+            agg ------------ |    |
+         ___| |___           |    |
+      L0 |       | L1        | TG |
+         |       |           |    |
+    infra[0] -- infra[1] --- |____|
+             L2         TG L1
 
     Configure:
         agg:
-            L0 and L1: master bridge
+            L0, L1, TG L0: master bridge
             bridge: ip address 192.168.1.5/24
         infra[0]:
             L0 (port/bridge): ip address 192.168.1.3/24
+            L2: ip address 192.168.3.10/24
+                route 192.168.2.2 via 192.168.3.11
         infra[1]:
             L1 (port/bridge): ip address 192.168.1.4/24
+            L2: ip address 192.168.3.11/24
+            TG L1: ip address 192.168.2.1/24
+        TG (if use_tgen=True):
+            L0: ip address 192.168.1.5/24
+            L1: ip address 192.168.2.2/24
     """
     tgen_dev, dent_devices = await tgen_utils_get_dent_devices_with_tgen(testbed, [
         DeviceType.AGGREGATION_ROUTER,
@@ -50,6 +69,8 @@ async def setup_topo_for_vrrp(testbed, use_bridge=False):
         pytest.skip('The testbed does not have enough agg devices')
     agg = agg[0]
 
+    dev_groups = {}
+    vlan_dev = None
     bridge = 'br0'
     ep_ip = '192.168.1.5/24'
     links = [
@@ -59,70 +80,172 @@ async def setup_topo_for_vrrp(testbed, use_bridge=False):
         # L1
         {infra[1]: infra[1].links_dict[agg.host_name][0][0],
          agg: infra[1].links_dict[agg.host_name][1][0]},
+        # L2
+        {infra[0]: infra[0].links_dict[infra[1].host_name][0][0],
+         infra[1]: infra[0].links_dict[infra[1].host_name][1][0]},
+    ]
+    tg_links = [
+        # L0
+        {tgen_dev: tgen_dev.links_dict[agg.host_name][0][0],
+         agg: tgen_dev.links_dict[agg.host_name][1][0]},
+        # L1
+        {tgen_dev: tgen_dev.links_dict[infra[1].host_name][0][0],
+         infra[1]: tgen_dev.links_dict[infra[1].host_name][1][0]},
     ]
 
-    # 1. Configure aggregation router
-    out = await IpLink.add(input_data=[{agg.host_name: [
-        {'name': bridge, 'type': 'bridge'}
-    ]}])
-    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-        'Failed to create bridge'
+    ip_link_config = {
+        agg.host_name: [{'device': links[0][agg], 'master': bridge, 'operstate': 'up'},
+                        {'device': links[1][agg], 'master': bridge, 'operstate': 'up'},
+                        {'device': bridge, 'operstate': 'up'}],
+        infra[0].host_name: [{'device': links[0][infra[0]], 'master': bridge, 'operstate': 'up'},
+                             {'device': links[2][infra[0]], 'operstate': 'up'},
+                             {'device': bridge, 'operstate': 'up'}],
+        infra[1].host_name: [{'device': links[1][infra[1]], 'master': bridge, 'operstate': 'up'},
+                             {'device': links[2][infra[1]], 'operstate': 'up'},
+                             {'device': bridge, 'operstate': 'up'}],
+    }
+    if use_vid is not None:  # Q-bridge
+        bridge_config = {
+            dent.host_name: [{'name': bridge, 'type': 'bridge', 'vlan_filtering': 1, 'vlan_default_pvid': 0}]
+            for dent in [agg, infra[0], infra[1]]
+        }
+    elif use_bridge:  # D-bridge
+        bridge_config = {
+            dent.host_name: [{'name': bridge, 'type': 'bridge'}]
+            for dent in [agg, infra[0], infra[1]]
+        }
+    else:  # port
+        bridge_config = {
+            agg.host_name: [{'name': bridge, 'type': 'bridge'}]
+        }
+        # do not enslave ports
+        del ip_link_config[infra[0].host_name][0]['master']
+        del ip_link_config[infra[1].host_name][0]['master']
+        # do not set bridge up
+        del ip_link_config[infra[0].host_name][-1]
+        del ip_link_config[infra[1].host_name][-1]
 
-    out = await IpLink.set(input_data=[{
-        agg.host_name: [
-            {'device': port, 'master': bridge, 'operstate': 'up'}
-            for port in [links[0][agg], links[1][agg]]
-        ] + [
-            {'device': bridge, 'operstate': 'up'}
-        ]
-    }])
+    if use_tgen:
+        ip_link_config[agg.host_name].append({'device': tg_links[0][agg],
+                                              'master': bridge, 'operstate': 'up'})
+        ip_link_config[infra[1].host_name].append({'device': tg_links[1][infra[1]],
+                                                   'operstate': 'up'})
+
+    # Add bridges
+    out = await IpLink.add(input_data=[bridge_config])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to create bridges'
+
+    # Enslave ports
+    out = await IpLink.set(input_data=[ip_link_config])
     assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
         'Failed to enslave ports'
 
-    # 2. Configure infra devices
-    if use_bridge:
+    # Add vlans and bridge vlan interfaces
+    if use_vid is not None:
+        agg_vlans = [
+            {'device': links[0][agg], 'vid': use_vid},
+            {'device': links[1][agg], 'vid': use_vid},
+        ]
+        if use_tgen:
+            agg_vlans.append({'device': tg_links[0][agg], 'vid': use_vid,
+                              'untagged': True, 'pvid': True})
+
+        out = await BridgeVlan.add(input_data=[{
+            agg.host_name: agg_vlans,
+            infra[0].host_name: [{'device': links[0][infra[0]], 'vid': use_vid},
+                                 {'device': bridge, 'vid': use_vid, 'self': True}],
+            infra[1].host_name: [{'device': links[1][infra[1]], 'vid': use_vid},
+                                 {'device': bridge, 'vid': use_vid, 'self': True}],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to add vlans'
+
+        vlan_dev = f'{bridge}.{use_vid}'
         out = await IpLink.add(input_data=[{
-            dent.host_name: [{'name': bridge, 'type': 'bridge'}]
+            dent.host_name: [{
+                'name': vlan_dev,
+                'link': bridge,
+                'type': f'vlan id {use_vid}',
+            }]
             for dent in infra
         }])
         assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-            'Failed to create bridge'
+            'Failed to create bridge vlan devices'
 
         out = await IpLink.set(input_data=[{
-            infra[0].host_name: [
-                {'device': links[0][infra[0]], 'operstate': 'up', 'master': bridge},
-                {'device': bridge, 'operstate': 'up'},
-            ],
-            infra[1].host_name: [
-                {'device': links[1][infra[1]], 'operstate': 'up', 'master': bridge},
-                {'device': bridge, 'operstate': 'up'},
-            ],
+            infra[0].host_name: [{'device': vlan_dev, 'operstate': 'up'}],
+            infra[1].host_name: [{'device': vlan_dev, 'operstate': 'up'}],
         }])
         assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-            'Failed to enslave ports'
+            'Failed to set operstate'
 
-        out = await IpAddress.add(input_data=[{
+        ip_addr_config = {
+            infra[0].host_name: [{'dev': vlan_dev, 'prefix': '192.168.1.3/24'}],
+            infra[1].host_name: [{'dev': vlan_dev, 'prefix': '192.168.1.4/24'}],
+        }
+    elif use_bridge:
+        ip_addr_config = {
             infra[0].host_name: [{'dev': bridge, 'prefix': '192.168.1.3/24'}],
             infra[1].host_name: [{'dev': bridge, 'prefix': '192.168.1.4/24'}],
-            agg.host_name: [{'dev': bridge, 'prefix': ep_ip}],
-        }])
-        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-            'Failed to add IP addr'
+        }
     else:  # port
-        out = await IpLink.set(input_data=[{
-            infra[0].host_name: [{'device': links[0][infra[0]], 'operstate': 'up'}],
-            infra[1].host_name: [{'device': links[1][infra[1]], 'operstate': 'up'}],
-        }])
-        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-            'Failed to set operstate to UP'
-
-        out = await IpAddress.add(input_data=[{
+        ip_addr_config = {
             infra[0].host_name: [{'dev': links[0][infra[0]], 'prefix': '192.168.1.3/24'}],
             infra[1].host_name: [{'dev': links[1][infra[1]], 'prefix': '192.168.1.4/24'}],
-            agg.host_name: [{'dev': bridge, 'prefix': ep_ip}],
+        }
+
+    # Add ip addrs
+    if use_tgen:
+        ip_addr_config[infra[1].host_name].append({'dev': tg_links[1][infra[1]], 'prefix': '192.168.2.1/24'})
+    else:
+        ip_addr_config[agg.host_name] = [{'dev': bridge, 'prefix': ep_ip}]
+
+    ip_addr_config[infra[0].host_name].append({'dev': links[2][infra[0]], 'prefix': '192.168.3.10/24'})
+    ip_addr_config[infra[1].host_name].append({'dev': links[2][infra[1]], 'prefix': '192.168.3.11/24'})
+
+    out = await IpAddress.add(input_data=[ip_addr_config])
+    assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+        'Failed to add IP addr'
+
+    # Configure TGen
+    if use_tgen:
+        tgen_ports = [tg_links[0][tgen_dev], tg_links[1][tgen_dev]]
+        dut_ports = [tg_links[0][agg], tg_links[1][infra[1]]]
+
+        dev_groups = tgen_utils_dev_groups_from_config([
+            {'ixp': tgen_ports[0], 'ip': ep_ip.split('/')[0], 'gw': vrrp_ip, 'plen': ep_ip.split('/')[1]},
+            {'ixp': tgen_ports[1], 'ip': '192.168.2.2', 'gw': '192.168.2.1', 'plen': 24},
+        ])
+        await tgen_utils_traffic_generator_connect(tgen_dev, tgen_ports, dut_ports, dev_groups)
+
+        # Add route to TG L1 from infra[0] via infra[1] L2
+        out = await IpRoute.add(input_data=[{
+            infra[0].host_name: [
+                {'dst': dev_groups[tg_links[1][tgen_dev]][0]['ip'],
+                 'nexthop': [{'via': '192.168.3.11'}]}
+            ],
         }])
         assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
-            'Failed to add IP addr'
+            'Failed to add route from infra[0] to TG L1 via infra[1]'
+
+        # FIXME
+        # Add static arp because for some reason the neighbor is aged and becomes
+        # invalid which causes traffic loss
+        out = await IpAddress.show(input_data=[{
+            infra[1].host_name: [{'dev': links[2][infra[1]], 'cmd_options': '-j'}]
+        }], parse_output=True)
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to get infra1 mac addr'
+
+        mac = out[0][infra[1].host_name]['parsed_output'][0]['address']
+        out = await IpNeighbor.replace(input_data=[{
+            infra[0].host_name: [
+                {'dev': links[2][infra[0]], 'address': '192.168.3.11', 'lladdr': mac}
+            ],
+        }])
+        assert all(res[host_name]['rc'] == 0 for res in out for host_name in res), \
+            'Failed to add static neighbor'
 
     return {
         'tgen_dev': tgen_dev,
@@ -131,6 +254,9 @@ async def setup_topo_for_vrrp(testbed, use_bridge=False):
         'bridge': bridge,
         'ep_ip': ep_ip,
         'links': links,
+        'tg_links': tg_links,
+        'dev_groups': dev_groups,
+        'vlan_dev': vlan_dev,
     }
 
 
@@ -153,3 +279,23 @@ async def verify_vrrp_ping(agg, infra, ports, expected, dst=None, count=10, inte
     captured = await asyncio.gather(*tcpdump)
     for dent, exp_pkt, actual_pkt in zip(infra, expected, captured):
         assert exp_pkt == actual_pkt, f'Expected {dent} to handle {exp_pkt} icmp packets'
+
+
+async def get_rx_bps(dent, port, sleep_for=5):
+    out = await Ethtool.show(input_data=[{dent: [
+        {'devname': port, 'options': '-S'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0
+
+    old_stats = int(out[0][dent]['parsed_output']['good_octets_received'])
+
+    await asyncio.sleep(sleep_for)
+
+    out = await Ethtool.show(input_data=[{dent: [
+        {'devname': port, 'options': '-S'}
+    ]}], parse_output=True)
+    assert out[0][dent]['rc'] == 0
+
+    new_stats = int(out[0][dent]['parsed_output']['good_octets_received'])
+
+    return (new_stats - old_stats) // sleep_for


### PR DESCRIPTION
New tests:

- test_vrrp_and_stp
- test_vrrp_preempt_on[bridge]
- test_vrrp_preempt_on[port]
- test_vrrp_under_traffic[bridge]
- test_vrrp_under_traffic[port]
- test_vrrp_under_traffic[vlan]
- test_vrrp_multiple_addr
- test_vrrp_max_instances
- test_vrrp_master_and_backup

Update setup_topo_for_vrrp function, which will allow to use:

- TG - DUT links
- links between infra devices
- VRRP over bridge or port or bridge vlan interfaces

Update verify_vrrp_ping function:

- Count only icmp reply packets.
- Pass interval as an argument.
- Add an argument to run tcpdump without running ping.

Add a generic polling function.

Signed-off-by: Serhiy Boiko [serhiy.boiko@plvision.eu](mailto:serhiy.boiko@plvision.eu)